### PR TITLE
ASOS-58: Fixed the page loading issue after clicking 'Delete' button on the Demographic Set Edit page under Report tab on the Main page nav bar.

### DIFF
--- a/src/main/java/oscar/oscarReport/pageUtil/DemographicSetEligibilityAction.java
+++ b/src/main/java/oscar/oscarReport/pageUtil/DemographicSetEligibilityAction.java
@@ -57,17 +57,27 @@ public class DemographicSetEligibilityAction extends Action {
         DemographicSets dsets = new DemographicSets();
         
         if (request.getParameter("delete")!= null && request.getParameter("delete").equals("Delete")){
-            for (int i = 0; i < s.length;i++){
-              dsets.setDemographicDelete(setName, s[i]);
-           }
-        }else{
-        
-            if(s != null){
-               for (int i = 0; i < s.length;i++){
-                  dsets.setDemographicIneligible(setName, s[i]);
-               }
+            if (s != null) {
+                for (int i = 0; i < s.length; i++) {
+                    dsets.setDemographicDelete(setName, s[i]);
+                }
+            } else {
+                // Handle the case where there is nothing to delete
+                // Log a warning or set a message to be shown to the user
+                request.setAttribute("errorMessage", "No demographics selected for deletion.");
             }
-        
+        }else{
+
+            if (s != null) {
+                for (int i = 0; i < s.length; i++) {
+                    dsets.setDemographicIneligible(setName, s[i]);
+                }
+            } else {
+                // Handle the case where there are no demographics to set ineligible
+                // Log a warning or set a message to be shown to the user
+                request.setAttribute("errorMessage", "No demographics selected for ineligibility.");
+            }
+      
         }
                 
         return mapping.findForward("success");


### PR DESCRIPTION
The page is loaded without error after clicking the 'Delete' button when there is no data existing (before it gets the NullPointerException error).