### PR TITLE
ASOS-64: Fixed the error when opening prescription module of patients with a prescription already prescribed.

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/PartialDateDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PartialDateDaoImpl.java
@@ -47,11 +47,12 @@
      @Override
      public PartialDate getPartialDate(Integer tableName, Integer tableId, Integer fieldName) {
  
-         String sqlCommand = "select x from PartialDate x where x.tableName=?1 and x.tableId=?2 and x.fieldName=?3 order by x.id desc limit 1";
+         String sqlCommand = "select x from PartialDate x where x.tableName=?1 and x.tableId=?2 and x.fieldName=?3 order by x.id desc";
          Query query = entityManager.createQuery(sqlCommand);
          query.setParameter(1, tableName);
          query.setParameter(2, tableId);
          query.setParameter(3, fieldName);
+         query.setMaxResults(1);
  
          @SuppressWarnings("unchecked")
          PartialDate result = null;
@@ -60,7 +61,7 @@
          } catch (NoResultException ex) {
              MiscUtils.getLogger().debug("Note",ex);
          }
- 
+         
          return result;
      }
      


### PR DESCRIPTION
The 500 error on the webpage is solved by modifying the getPartialDate method in the PartialDateDaoImpl.java file. The page can be loaded without error.