### PR TITLE
Database implementation and clean-up

### DIFF
--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -23,8 +23,5 @@ RUN chmod 644 /etc/mysql/my.cnf
 RUN dos2unix /docker-entrypoint-initdb.d/populate_db.sh
 RUN dos2unix /database/mysql/*.sh
 
-# Make the script executable
-RUN chmod +x /docker-entrypoint-initdb.d/populate_db.sh
-
 # Ports
 EXPOSE 3306

--- a/.devcontainer/db/Dockerfile
+++ b/.devcontainer/db/Dockerfile
@@ -23,5 +23,8 @@ RUN chmod 644 /etc/mysql/my.cnf
 RUN dos2unix /docker-entrypoint-initdb.d/populate_db.sh
 RUN dos2unix /database/mysql/*.sh
 
+# Make the script executable
+RUN chmod +x /docker-entrypoint-initdb.d/populate_db.sh
+
 # Ports
 EXPOSE 3306

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -10,6 +10,4 @@ echo 'Creating test database...'
 ./createdatabase_on.sh root password oscar_test
 echo 'Creating drugref2 database...'
 mysql -u root -ppassword drugref2 < /database/mysql/updated-drugref.sql
-echo 'Creating oscar database...'
-mysql -u root -ppassword oscar < /database/mysql/backup.sql
 cd ../../

--- a/.devcontainer/db/scripts/populate_db.sh
+++ b/.devcontainer/db/scripts/populate_db.sh
@@ -8,4 +8,8 @@ echo 'Creating development database...'
 ./createdatabase_on.sh root password oscar
 echo 'Creating test database...'
 ./createdatabase_on.sh root password oscar_test
+echo 'Creating drugref2 database...'
+mysql -u root -ppassword drugref2 < /database/mysql/updated-drugref.sql
+echo 'Creating oscar database...'
+mysql -u root -ppassword oscar < /database/mysql/backup.sql
 cd ../../

--- a/database/mysql/createdatabase_generic.sh
+++ b/database/mysql/createdatabase_generic.sh
@@ -21,8 +21,8 @@ echo "grant all on $DATABASE_NAME.* to $USER@localhost identified by \"$PASSWORD
 echo 'updating character set to utf8'
 echo "alter database $DATABASE_NAME DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci" | $mysql_cmd
 
-echo 'loading oscarinit.sql...'
-$mysql_cmd < oscarinit.sql
+echo 'loading backup.sql...'
+$mysql_cmd < magenta-backup.sql
 echo "loading oscarinit_$LOCATION.sql..."
 $mysql_cmd < oscarinit_$LOCATION.sql
 echo 'loading oscardata.sql...'


### PR DESCRIPTION
Implemented the drugref.sql (drugref2 db) and magenta-backup.sql (oscar db) into the .devcontainer.
Cleaned up the backup.sql file:
- Empty the document table.
- Empty the eform and eform_data tables.
- Empty the DigitalSignature table.
- Empty the messagetbl table.
- Change some of the patients' names.
- Removed the secret data which is for the new email feature (in emailConfig table).
- Replaced all emails and phones with the generic email address and phone number.
- Replaced Deval, Keith, and Kimoon names to the fake names.