### PR TITLE
QA_ASOS-181&187

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,35 +423,35 @@
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts-core</artifactId>
-			<version>1.3.10</version>
+			<version>1.3.8</version>
 		</dependency>
 
 		<!-- Struts Taglib Library -->
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts-taglib</artifactId>
-			<version>1.3.10</version>
+			<version>1.3.8</version>
 		</dependency>
 
 		<!-- Struts Tiles Library -->
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts-tiles</artifactId>
-			<version>1.3.10</version>
+			<version>1.3.8</version>
 		</dependency>
 
 		<!-- Struts Extras Library -->
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts-extras</artifactId>
-			<version>1.3.10</version>
+			<version>1.3.8</version>
 		</dependency>
 
 		<!-- Struts El Library -->
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts-el</artifactId>
-			<version>1.3.10</version>
+			<version>1.3.8</version>
 		</dependency>
 
 		<!-- Commons Digester Library -->

--- a/src/main/java/org/oscarehr/casemgmt/dao/ClientImageDAOImpl.java
+++ b/src/main/java/org/oscarehr/casemgmt/dao/ClientImageDAOImpl.java
@@ -81,7 +81,7 @@ public class ClientImageDAOImpl extends HibernateDaoSupport implements ClientIma
                 clientImage = results.get(0);
 
                 // add to cache if it's less than ... say 1 megs
-                if (clientImage.getImage_data().length < 1024000) {
+                if (clientImage.getImage_data() != null && clientImage.getImage_data().length < 1024000) {
                     dataCache.put(clientId, clientImage);
                     logger.debug("entry found in db, adding to dataCache : clientId=" + clientId);
                 }

--- a/src/main/java/org/oscarehr/casemgmt/model/ClientImage.java
+++ b/src/main/java/org/oscarehr/casemgmt/model/ClientImage.java
@@ -26,18 +26,16 @@ package org.oscarehr.casemgmt.model;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.sql.Blob;
+import java.sql.SQLException;
 import java.util.Date;
+
+import javax.sql.rowset.serial.SerialBlob;
 
 import org.apache.commons.codec.binary.Base64;
 import org.caisi.model.BaseObject;
-import org.hibernate.Hibernate;
 import org.oscarehr.util.MiscUtils;
-import org.hibernate.Session;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.hibernate.SessionFactory;
-import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
-public class ClientImage extends HibernateDaoSupport {
+public class ClientImage extends BaseObject {
 	public static final String imageMissingPlaceholderUrl="/images/defaultR_img.jpg";
 	public static final String imagePresentPlaceholderUrl="/images/default_img.jpg";
 	
@@ -46,13 +44,6 @@ public class ClientImage extends HibernateDaoSupport {
 	private String image_type;
 	private byte[] image_data;
 	private Date update_date;
-
-	public SessionFactory sessionFactory;
-
-	@Autowired
-    public void setSessionFactoryOverride(SessionFactory sessionFactory) {
-        super.setSessionFactory(sessionFactory);
-    }
 	
 	public ClientImage() {
 		update_date = new Date();
@@ -99,12 +90,16 @@ public class ClientImage extends HibernateDaoSupport {
 	}
 
 	public Blob getImage_contents() {
-		Session session = sessionFactory.getCurrentSession();
 		if(image_data == null) {
 			return null;
 		}
-		//return Hibernate.createBlob(Base64.encodeBase64(getImage_data()));
-		return Hibernate.getLobCreator(session).createBlob(getImage_data());
+		try {
+			Blob imageBlob = new SerialBlob(Base64.encodeBase64(image_data));
+			return imageBlob;
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return null;
 	}
 
 	public void setImage_contents(Blob image_contents) {


### PR DESCRIPTION
Downgraded the struts version from 1.3.10 to 1.3.8, which fixed the error thrown when uploading the HL7 lab form (ASOS-181), and the struts error thrown when uploading the image in patient's eChart.

Andrew suggested to switched HibernateDao to the BaseObject - its to match previous behavior. Shouldn't need any direct database related functionality in the model object which got added due to a function changing in-between hibernate versions. We swapped that function out and now no longer need to extend to hibernatedao or include any hibernate/session related functions. This change fixed the image uploading issue.