### PR TITLE
ASOS-182-ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ProfessionalSpecialistDaoImpl.java
@@ -155,12 +155,12 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 		if(searchMode.equals("search_name")) {
 			String[] temp = keyword.split("\\,\\p{Space}*");
 			if(temp.length>1) {
-		      where.append("c.lastName like ?1 and c.firstName like ?2");
+		      where.append("c.lastName like ? and c.firstName like ?");
+		      paramList.add(temp[0]+"%");
 		      paramList.add(temp[1]+"%");
-		      paramList.add(temp[2]+"%");
 		    } else {
-		      where.append("c.lastName like ?1");
-		      paramList.add(temp[1]+"%");
+		      where.append("c.lastName like ?");
+		      paramList.add(temp[0]+"%");
 		    }
 		}		
 		String sql = "SELECT c from ProfessionalSpecialist c where " + where.toString() + " order by " + orderBy;


### PR DESCRIPTION
The 'ArryIndexOutOfBoundsException' error caused by ProfessionalsSpecialistDaoImpl.search is fixed, no error thrown when typing in the fax form.

Removed the position mapping since it caused the error - the code tried to access temp[1] and temp[2] without checking if the temp array has enough elements. Removing the position mapping and changing the index position from 0 fixed the issue properly.