### PR TITLE
ASOS 197 - Overdue Measurements

### DIFF
--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/MeasurementFlowSheet.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/MeasurementFlowSheet.java
@@ -217,10 +217,10 @@ public class MeasurementFlowSheet {
         FlowSheetItem item = (FlowSheetItem) itemList.get(measurement);
 
         if (item == null) {
-        log.warn("No item found for measurement: " + measurement);
-        
-        return new HashMap<>(); // Return an empty map or handle it as needed
-    }
+            log.warn("No item found for measurement: " + measurement);
+
+            return new HashMap<>(); // Return an empty map or handle it as needed
+        }
 
         return item.getAllFields();
     }

--- a/src/main/java/oscar/oscarEncounter/oscarMeasurements/MeasurementFlowSheet.java
+++ b/src/main/java/oscar/oscarEncounter/oscarMeasurements/MeasurementFlowSheet.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -211,8 +212,15 @@ public class MeasurementFlowSheet {
          //DO something
         	itemList = new ListOrderedMap();
         }
+
         log.debug("GETTING "+measurement+ " ITEMS IN THE LIST "+itemList.size());
         FlowSheetItem item = (FlowSheetItem) itemList.get(measurement);
+
+        if (item == null) {
+        log.warn("No item found for measurement: " + measurement);
+        
+        return new HashMap<>(); // Return an empty map or handle it as needed
+    }
 
         return item.getAllFields();
     }


### PR DESCRIPTION
Before, the code had no null check for this particular methods return value. As such, this would throw a 500 error if the user had not selected any of the checkbox options and also selected the add button. 

Now, there is another null check before the end of the method that will determine if the item is null, which if so, will create an empty hash map to return from the method. 

This avoids the 500 error and will still allow the user to proceed to the next page as required for the intended workflow.