### PR TITLE
ASOS 198 Searching By Provider Number

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/ProviderDataDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ProviderDataDaoImpl.java
@@ -91,7 +91,7 @@ public class ProviderDataDaoImpl extends AbstractDaoImpl<ProviderData> implement
 		Query query = entityManager.createQuery(sqlCommand);
 		query.setFirstResult(offset);
 		query.setMaxResults(limit);
-		query.setParameter(1, providerNo + "%");
+		query.setParameter(0, providerNo + "%");
 		if(status != null)
 			query.setParameter("status", status);
 


### PR DESCRIPTION
Implemented a minor change to adjust a parameter value from 1 to 0 to allow users to search for providers by their specific provider number.

Before, this would throw a 500 error on the webpage. However, even if a specific number is not provided and the user selects the search button the list of all providers will be shown to the user as intended. 