### PR TITLE
Positional Parameter Discrepancies

### DIFF
--- a/src/main/java/org/oscarehr/eyeform/dao/EyeformOcularProcedureDao.java
+++ b/src/main/java/org/oscarehr/eyeform/dao/EyeformOcularProcedureDao.java
@@ -58,9 +58,9 @@ public class EyeformOcularProcedureDao extends AbstractDaoImpl<EyeformOcularProc
 	public List<EyeformOcularProcedure> getByDateRange(int demographicNo,Date startDate, Date endDate) {
 		String sql="select x from "+modelClass.getSimpleName()+" x where x.demographicNo=? and x.date >= ? and x.date <=?";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, demographicNo);
-		query.setParameter(2, startDate);
-		query.setParameter(3, endDate);
+		query.setParameter(0, demographicNo);
+		query.setParameter(1, startDate);
+		query.setParameter(2, endDate);
 	    
 		@SuppressWarnings("unchecked")
 	    List<EyeformOcularProcedure> results=query.getResultList();
@@ -98,8 +98,8 @@ public class EyeformOcularProcedureDao extends AbstractDaoImpl<EyeformOcularProc
 	public List<EyeformOcularProcedure> getAllPreviousAndCurrent(int demographicNo, int appointmentNo) {
 		String sql="select x from "+modelClass.getSimpleName()+" x where x.demographicNo = ? and x.appointmentNo<=?";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, demographicNo);	    
-		query.setParameter(2, appointmentNo);
+		query.setParameter(0, demographicNo);	    
+		query.setParameter(1, appointmentNo);
 	    
 		@SuppressWarnings("unchecked")
 	    List<EyeformOcularProcedure> results=query.getResultList();

--- a/src/main/java/org/oscarehr/eyeform/dao/EyeformSpecsHistoryDao.java
+++ b/src/main/java/org/oscarehr/eyeform/dao/EyeformSpecsHistoryDao.java
@@ -55,9 +55,9 @@ public class EyeformSpecsHistoryDao extends AbstractDaoImpl<EyeformSpecsHistory>
 	public List<EyeformSpecsHistory> getByDateRange(int demographicNo,Date startDate, Date endDate) {
 		String sql="select x from "+modelClass.getSimpleName()+" x where x.demographicNo=? and x.date >= ? and x.date <=?";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, demographicNo);
-		query.setParameter(2, startDate);
-		query.setParameter(3, endDate);
+		query.setParameter(0, demographicNo);
+		query.setParameter(1, startDate);
+		query.setParameter(2, endDate);
 	    
 		@SuppressWarnings("unchecked")
 	    List<EyeformSpecsHistory> results=query.getResultList();
@@ -95,8 +95,8 @@ public class EyeformSpecsHistoryDao extends AbstractDaoImpl<EyeformSpecsHistory>
 	public List<EyeformSpecsHistory> getAllPreviousAndCurrent(int demographicNo, int appointmentNo) {
 		String sql="select x from "+modelClass.getSimpleName()+" x where x.demographicNo = ? and x.appointmentNo<=? order by x.date DESC";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, demographicNo);	    
-		query.setParameter(2, appointmentNo);
+		query.setParameter(0, demographicNo);	    
+		query.setParameter(1, appointmentNo);
 	    
 		@SuppressWarnings("unchecked")
 	    List<EyeformSpecsHistory> results=query.getResultList();

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
@@ -28,7 +28,7 @@ public class HRMCategoryDao extends AbstractDaoImpl<HRMCategory> {
 	public List<HRMCategory> findById(int id) {
 		String sql = "select x from " + this.modelClass.getName() + " x where x.id=?";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, id);
+		query.setParameter(0, id);
 		@SuppressWarnings("unchecked")
 		List<HRMCategory> documents = query.getResultList();
 		return documents;

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMSubClassDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMSubClassDao.java
@@ -27,7 +27,7 @@ public class HRMSubClassDao extends AbstractDaoImpl<HRMSubClass> {
 	public List<HRMSubClass> findById(int id) {
 		String sql = "select x from " + this.modelClass.getName() + " x where x.id=?";
 		Query query = entityManager.createQuery(sql);
-		query.setParameter(1, id);
+		query.setParameter(0, id);
 		@SuppressWarnings("unchecked")
 		List<HRMSubClass> documents = query.getResultList();
 		return documents;

--- a/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
@@ -28,7 +28,7 @@ public class OLISProviderPreferencesDao extends AbstractDaoImpl<OLISProviderPref
 		try {
 			String sql = "select x from "+ this.modelClass.getName() + " x where x.providerId=?";
 			Query query = entityManager.createQuery(sql);
-			query.setParameter(1, id);		
+			query.setParameter(0, id);		
 			return (OLISProviderPreferences)query.getSingleResult();
 		}
 		catch (javax.persistence.NoResultException nre) {


### PR DESCRIPTION
Multiple files were found with wrong positional parameters. The following command was used to find the files:

grep -rl 'select x from' . --include='*.java' | xargs awk '/select x from/ {getline; getline; if (/query.setParameter/) print FILENAME ":" FNR-2, $0}'

This would look for files that included the select statement alongside query.setParameter two lines below that statement as most of the files had proper line spacing.

Each change in the files was due to query statements not including mapping and starting at 1 instead of 0.

Any that were found have been changed and there is also a .txt file in the teams folder that will include all the files that were checked that had any positional parameters starting at 1 or higher. Files that had positional parameters already set to 0 were removed. 