### PR TITLE
Small Method Change For Saving Notes

### DIFF
--- a/src/main/java/org/oscarehr/casemgmt/dao/CaseManagementNoteDAOImpl.java
+++ b/src/main/java/org/oscarehr/casemgmt/dao/CaseManagementNoteDAOImpl.java
@@ -539,7 +539,7 @@ public class CaseManagementNoteDAOImpl extends HibernateDaoSupport implements Ca
     public void updateNote(CaseManagementNote note) {
         note.setUpdate_date(new Date());
         this.getHibernateTemplate().update(note);
-        this.getHibernateTemplate().clear();
+        this.getHibernateTemplate().flush();
     }
 
     @Override
@@ -551,7 +551,7 @@ public class CaseManagementNoteDAOImpl extends HibernateDaoSupport implements Ca
         }
         note.setUpdate_date(new Date());
         this.getHibernateTemplate().save(note);
-        this.getHibernateTemplate().clear();
+        this.getHibernateTemplate().flush();
     }
 
     @Override


### PR DESCRIPTION
In a previous code change to be able to save a note twice, getHibernateTemplate().clear() was used to detach all objects from a user's current session. This was able to fix that issue, but introduced a new one where a user could not assign an "Issue" to a note (this would change the background color of the note for specific issues).

With the new change, clear() was simply replaced with flush() to allow for a direct call to synchronize the database at the end of the saving methods. This will allow users to be able to save notes twice and also have the implementation of the colored notes for specific issues. 

I suspect it was due to all the objects being detached from the session when clear() was called before the Issue was properly assigned to the note in the database.