### PR TITLE
Refactored updateProviderRoles method

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAO.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAO.java
@@ -75,5 +75,5 @@ public interface ProgramProviderDAO {
 
     public List<Facility> getFacilitiesInProgramDomain(String providerNo);
 
-    public void updateProviderRoles(Long providerId, Long roleId);
+    public void updateProviderRole(ProgramProvider pp, Long roleId);
 }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
@@ -337,9 +337,10 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
         return results;
     }
 
+    @Transactional
     @Override
-    public void updateProviderRoles(Long providerId, Long roleId) {
-        getHibernateTemplate().bulkUpdate("UPDATE ProgramProvider pp SET pp.RoleId = ? WHERE pp.Id = ?",
-                new Object[] { roleId, providerId });
+    public void updateProviderRole(ProgramProvider pp, Long roleId) {
+        pp.setRoleId(roleId);
+        getHibernateTemplate().update(pp);
     }
 }

--- a/src/test/java/org/oscarehr/common/dao/ProgramProviderDaoTest.java
+++ b/src/test/java/org/oscarehr/common/dao/ProgramProviderDaoTest.java
@@ -41,7 +41,6 @@ public class ProgramProviderDaoTest extends DaoTestFixtures {
 		SchemaUtils.restoreTable("program_provider");
 	}
 
-    @Ignore
 	@Test
 	public void testUpdateProviderRoles() throws Exception {
 		ProgramProvider pp = new ProgramProvider();
@@ -50,6 +49,6 @@ public class ProgramProviderDaoTest extends DaoTestFixtures {
 		
 		dao.saveProgramProvider(pp);
 		
-		dao.updateProviderRoles(pp.getId(), 19999l);
+		dao.updateProviderRole(pp, 19999l);
 	}
 }


### PR DESCRIPTION
Used getHibernateTemplate().u…pdate() and renamed to updateProviderRole

- Changed method arguments to accept ProgramProvider entity and roleId.
- Removed bulkUpdate query in favor of updating the entity using the setRoleId() method and Hibernate's update().
- As providerId is primary key, bulkupdate is unnecessary