### PR TITLE
fix: typo in maven-fluido-skin version

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>2.0.0-M10v</version>
+    <version>2.0.0-M10</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
Remove `v` in version number.