### PR TITLE
Mount ssh keys inside devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,12 @@
 		}
 		}
 	},
+	"mounts": [
+		"source=/run/host-services/ssh-auth.sock,target=/ssh-agent,type=bind"
+	],
+	"remoteEnv": {
+		"SSH_AUTH_SOCK": "/ssh-agent"
+	},
 	"forwardPorts": [
 		8080,
 		3306

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
         "redhat.fabric8-analytics",
         "vscjava.vscode-java-pack"
       ],
-      settings: {
+      "settings": {
         "terminal.integrated.shell.linux": "/bin/bash"
       }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,26 @@
 {
-  "name": "Open-OSP EMR Dev",
-  "workspaceFolder": "/workspace",
-  "dockerComposeFile": "docker-compose.yml",
-  "service": "oscar",
-  "shutdownAction": "stopCompose",
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "waderyan.gitblame",
-        "redhat.vscode-community-server-connector@0.25.7",
-        "redhat.fabric8-analytics",
-        "vscjava.vscode-java-pack"
-      ],
-      "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
-      }
-    }
-  },
-  "forwardPorts": [
-    8080,
-    3306
-  ],
-  "containerUser": "root",
-  "remoteUser": "root"
+	"name": "Open-OSP EMR Dev",
+	"workspaceFolder": "/workspace",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "oscar",
+	"shutdownAction": "stopCompose",
+	"customizations": {
+		"vscode": {
+		"extensions": [
+			"waderyan.gitblame",
+			"redhat.vscode-community-server-connector@0.25.7",
+			"redhat.fabric8-analytics",
+			"vscjava.vscode-java-pack"
+		],
+		"settings": {
+			"terminal.integrated.shell.linux": "/bin/bash"
+		}
+		}
+	},
+	"forwardPorts": [
+		8080,
+		3306
+	],
+	"containerUser": "root",
+	"remoteUser": "root"
 }


### PR DESCRIPTION
## Changes made
- Mount HOME/.ssh folder inside devcontainer.
  - Allows us to use ssh auth with git. 
- Surround `settings` with double quotes.
- Change indentation from spaces to tabs.