### PR TITLE
Patch for Apache commons library, dependency lock updates

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -994,11 +994,11 @@
   }, {
     "groupId" : "net.java.dev.jna",
     "artifactId" : "jna",
-    "version" : "5.14.0",
+    "version" : "5.15.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:m0lj0EnHNRkqRiFrOS5fcYqiRB9Msxj5mRiMCsObGj2jHpHaAcynxrs3dytKPZ2MoY7XGbrVTTNNpAFh9J4usg=="
+    "integrity" : "sha512:Nfr+zgyK+pXglOfGJ4ANDOAky/1bZxEHV+sw1F3PwxB+q3Wvn+xJi2Kfm3kLKviSegk6coPTSPeyEPRTPPd8og=="
   }, {
     "groupId" : "net.oauth.core",
     "artifactId" : "oauth-provider",
@@ -1227,11 +1227,11 @@
   }, {
     "groupId" : "org.apache.commons",
     "artifactId" : "commons-text",
-    "version" : "1.9",
+    "version" : "1.10.0",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:rTl4fJZEVzeQTjQ1k8A6pMTna9FRb/RecPwe/YpTQ5sbEEw7D+1OQx2Skeur9L/y5VR+DGUQ9ZFguOpiC60q4g=="
+    "integrity" : "sha512:r9g2oQlESeCnkf7mc2NmbEe20krP81OlCJuDezMsD0r4lWXDVGglIeNwYtIOa1LXDHe7TyTMqblTLCdPxwioMQ=="
   }, {
     "groupId" : "org.apache.cxf.services.sts",
     "artifactId" : "cxf-services-sts-core",

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
             <version>1.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        
         <!--Log4j-2 libraries-->
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
         <dependency>


### PR DESCRIPTION
Update library due to CVE, update dependency lock. 
Additional fix to catch up with missing one for last library version update, but without dependency lock. 