### PR TITLE
Set SSH_AUTH_SOCK as containerEnv.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 			"target": "/ssh-agent"
 		}
 	],
-	"remoteEnv": {
+	"containerEnv": {
 		"SSH_AUTH_SOCK": "/ssh-agent"
 	},
 	"forwardPorts": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"workspaceFolder": "/workspace",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "open-o",
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
 	"shutdownAction": "stopCompose",
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
Environment variables set with `containerEnv` are static.

This will prevent `SSH_AUTH_SOCK` from being overwritten by a process _in_ the devcontainer.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set SSH_AUTH_SOCK as a static environment variable using containerEnv in the devcontainer configuration to ensure it remains unchanged by internal processes.

Deployment:
- Set SSH_AUTH_SOCK as a static environment variable using containerEnv in the devcontainer configuration to prevent it from being overwritten by processes within the container.

<!-- Generated by sourcery-ai[bot]: end summary -->