### PR TITLE
Refactored queries to use JPA API in ProgramDaoImpl and ProgramAccessDAOImpl classes.

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramAccessDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramAccessDAOImpl.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 /**
  * Copyright (c) 2024. Magenta Health. All Rights Reserved.
  * <p>
@@ -29,28 +28,50 @@ package org.oscarehr.PMmodule.dao;
 
 import java.util.List;
 
+import javax.persistence.TypedQuery;
+
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.logging.log4j.Logger;
 import org.oscarehr.PMmodule.model.AccessType;
 import org.oscarehr.PMmodule.model.ProgramAccess;
+import org.oscarehr.common.dao.AbstractDaoImpl;
 import org.oscarehr.util.MiscUtils;
 import org.oscarehr.util.QueueCache;
-import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
+import org.springframework.stereotype.Repository;
 
-public class ProgramAccessDAOImpl extends HibernateDaoSupport implements ProgramAccessDAO {
+/**
+ * Implementation of ProgramAccessDAO interface for database access to ProgramAccess model objects.
+ */
+@Repository
+public class ProgramAccessDAOImpl extends AbstractDaoImpl<ProgramAccess> implements ProgramAccessDAO {
 
     private static Logger log = MiscUtils.getLogger();
 
     private static QueueCache<Long, List<ProgramAccess>> programAccessListByProgramIdCache = new QueueCache<Long, List<ProgramAccess>>(
             4, 100, DateUtils.MILLIS_PER_HOUR, null);
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Default constructor.
+     * Calls the parent constructor with ProgramAccess model class.
+     */
+    public ProgramAccessDAOImpl() {
+        super(ProgramAccess.class);
+    }
+
+    /**
+     * Retrieves the list of ProgramAccess objects associated with a specific program ID.
+     * 
+     * @param programId the ID of the program
+     * @return a list of ProgramAccess objects associated with the specified program ID
+     */
     @Override
     public List<ProgramAccess> getAccessListByProgramId(Long programId) {
         List<ProgramAccess> results = programAccessListByProgramIdCache.get(programId);
         if (results == null) {
-            String q = "select pp from ProgramAccess pp where pp.ProgramId=?0";
-            results = (List<ProgramAccess>) getHibernateTemplate().find(q, new Object[]{programId});
+            String q = "select pp from ProgramAccess pp where pp.ProgramId=?1";
+            TypedQuery<ProgramAccess> query = entityManager.createQuery(q, ProgramAccess.class);
+            query.setParameter(1, programId);
+            results = query.getResultList();
             if (results != null)
                 programAccessListByProgramIdCache.put(programId, results);
         }
@@ -58,14 +79,21 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         return results;
     }
 
-    @Override
+    /**
+     * Retrieves a ProgramAccess object by its ID.
+     * 
+     * @param id the ID of the ProgramAccess object to retrieve
+     * @return the ProgramAccess object if found, null otherwise
+     * @throws IllegalArgumentException if the ID is null or less than or equal to 0
+     */
+    @Override 
     public ProgramAccess getProgramAccess(Long id) {
 
         if (id == null || id.intValue() <= 0) {
             throw new IllegalArgumentException();
         }
 
-        ProgramAccess result = this.getHibernateTemplate().get(ProgramAccess.class, id);
+        ProgramAccess result = entityManager.find(ProgramAccess.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramAccess: id=" + id + ",found=" + (result != null));
@@ -73,6 +101,14 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         return result;
     }
 
+    /**
+     * Retrieves a ProgramAccess object by program ID and access type ID.
+     * 
+     * @param programId the ID of the program
+     * @param accessTypeId the ID of the access type
+     * @return the ProgramAccess object if found, null otherwise
+     * @throws IllegalArgumentException if either programId or accessTypeId is null or less than or equal to 0
+     */
     @Override
     public ProgramAccess getProgramAccess(Long programId, Long accessTypeId) {
         if (programId == null || programId.intValue() <= 0) {
@@ -83,11 +119,13 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         }
         String accessTypeIdString = accessTypeId.toString();
         ProgramAccess result = null;
-        List results = this.getHibernateTemplate().find(
-                "from ProgramAccess pa where pa.ProgramId = ? and pa.AccessTypeId = ?",
-                new Object[]{programId, accessTypeIdString});
-        if (results.size() > 0) {
-            result = (ProgramAccess) results.get(0);
+        String q = "from ProgramAccess pa where pa.ProgramId = ?1 and pa.AccessTypeId = ?2";
+        TypedQuery<ProgramAccess> query = entityManager.createQuery(q, ProgramAccess.class);
+        query.setParameter(1, programId);
+        query.setParameter(2, accessTypeIdString);
+        List<ProgramAccess> results = query.getResultList();
+        if (!results.isEmpty()) {
+            result = results.get(0);
         }
 
         if (log.isDebugEnabled()) {
@@ -98,20 +136,35 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Retrieves a list of ProgramAccess objects by program ID and access type name.
+     * 
+     * @param programId the ID of the program
+     * @param accessType the name of the access type
+     * @return a list of ProgramAccess objects matching the specified program ID and access type name
+     */
     @Override
     public List<ProgramAccess> getProgramAccessListByType(Long programId, String accessType) {
-        String q = "from ProgramAccess pa where pa.ProgramId = ? and pa.AccessType.Name like ?";
-        return (List<ProgramAccess>) this.getHibernateTemplate().find(q, new Object[]{programId, accessType});
+        String q = "from ProgramAccess pa where pa.ProgramId = ?1 and pa.AccessType.Name like ?2";
+        TypedQuery<ProgramAccess> query = entityManager.createQuery(q, ProgramAccess.class);
+        query.setParameter(1, programId);
+        query.setParameter(2, accessType);
+        return query.getResultList();
     }
 
+    /**
+     * Saves a ProgramAccess object.
+     * 
+     * @param pa the ProgramAccess object to save
+     * @throws IllegalArgumentException if the ProgramAccess object is null
+     */
     @Override
     public void saveProgramAccess(ProgramAccess pa) {
         if (pa == null) {
             throw new IllegalArgumentException();
         }
 
-        getHibernateTemplate().saveOrUpdate(pa);
+        entityManager.merge(pa);
         programAccessListByProgramIdCache.remove(pa.getProgramId());
 
         if (log.isDebugEnabled()) {
@@ -119,15 +172,23 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         }
     }
 
+    /**
+     * Deletes a ProgramAccess object by its ID.
+     * 
+     * @param id the ID of the ProgramAccess object to delete
+     * @throws IllegalArgumentException if the ID is null or less than or equal to 0
+     */
     @Override
     public void deleteProgramAccess(Long id) {
         if (id == null || id.intValue() <= 0) {
             throw new IllegalArgumentException();
         }
 
-        ProgramAccess pa = getProgramAccess(id);
-        programAccessListByProgramIdCache.remove(pa.getProgramId());
-        this.getHibernateTemplate().delete(pa);
+        ProgramAccess pa = entityManager.find(ProgramAccess.class, id);
+        if (pa != null) {
+            programAccessListByProgramIdCache.remove(pa.getProgramId());
+            entityManager.remove(pa);
+        }
 
         if (log.isDebugEnabled()) {
             log.debug("deleteProgramAccess:" + id);
@@ -135,9 +196,14 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
 
     }
 
+    /**
+     * Retrieves a list of all AccessType objects.
+     * 
+     * @return a list of AccessType objects
+     */
     @Override
     public List<AccessType> getAccessTypes() {
-        List<AccessType> results = (List<AccessType>) this.getHibernateTemplate().find("from AccessType at");
+        List<AccessType> results = entityManager.createQuery("from AccessType at", AccessType.class).getResultList();
 
         if (log.isDebugEnabled()) {
             log.debug("getAccessTypes: # of results=" + results.size());
@@ -145,13 +211,20 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         return results;
     }
 
+    /**
+     * Retrieves an AccessType object by its ID.
+     * 
+     * @param id the ID of the AccessType object to retrieve
+     * @return the AccessType object if found, null otherwise
+     * @throws IllegalArgumentException if the ID is null or less than or equal to 0
+     */
     @Override
     public AccessType getAccessType(Long id) {
         if (id == null || id.intValue() <= 0) {
             throw new IllegalArgumentException();
         }
 
-        AccessType result = this.getHibernateTemplate().get(AccessType.class, id);
+        AccessType result = entityManager.find(AccessType.class, id);
 
         if (log.isDebugEnabled()) {
             log.debug("getAccessType: id=" + id + ",found=" + (result != null));

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramDaoImpl.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 /**
  * Copyright (c) 2024. Magenta Health. All Rights Reserved.
  * <p>
@@ -24,7 +23,6 @@
  * <p>
  * Modifications made by Magenta Health in 2024.
  */
-
 package org.oscarehr.PMmodule.dao;
 
 import java.util.ArrayList;
@@ -33,33 +31,36 @@ import java.util.List;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.Logger;
-import org.hibernate.Criteria;
-import org.hibernate.FlushMode;
-import org.hibernate.Session;
-import org.hibernate.criterion.Expression;
-import org.hibernate.criterion.Order;
-import org.hibernate.criterion.Restrictions;
 import org.oscarehr.PMmodule.model.Program;
+import org.oscarehr.common.dao.AbstractDaoImpl;
 import org.oscarehr.util.MiscUtils;
-import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.hibernate.SessionFactory;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import oscar.OscarProperties;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.*;
 
+/**
+ * Implementation of ProgramDao interface for database access to Program model objects.
+ */
 @Transactional
-public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
+public class ProgramDaoImpl extends AbstractDaoImpl<Program> implements ProgramDao {
 
     private static final Logger log = MiscUtils.getLogger();
-    // public SessionFactory sessionFactory;
 
-    @Autowired
-    public void setSessionFactoryOverride(SessionFactory sessionFactory) {
-        super.setSessionFactory(sessionFactory);
+    /**
+     * Default constructor. 
+     * Calls the parent constructor with Program model class.
+     */
+    public ProgramDaoImpl() {
+        super(Program.class); 
     }
 
+    /**
+     * Checks if the specified program is a bed program.
+     * 
+     * @param programId the ID of the program to check
+     * @return true if the program is a bed program, false otherwise
+     */
     @Override
     public boolean isBedProgram(Integer programId) {
         Program result = getProgram(programId);
@@ -68,6 +69,12 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (result.isBed());
     }
 
+    /**
+     * Checks if the specified program is a service program.
+     * 
+     * @param programId the ID of the program to check
+     * @return true if the program is a service program, false otherwise
+     */
     @Override
     public boolean isServiceProgram(Integer programId) {
         Program result = getProgram(programId);
@@ -76,6 +83,12 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (result.isService());
     }
 
+    /**
+     * Checks if the specified program is a community program.
+     * 
+     * @param programId the ID of the program to check
+     * @return true if the program is a community program, false otherwise
+     */
     @Override
     public boolean isCommunityProgram(Integer programId) {
         Program result = getProgram(programId);
@@ -84,6 +97,12 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (result.isCommunity());
     }
 
+    /**
+     * Checks if the specified program is an external program.
+     * 
+     * @param programId the ID of the program to check
+     * @return true if the program is an external program, false otherwise
+     */
     @Override
     public boolean isExternalProgram(Integer programId) {
         Program result = getProgram(programId);
@@ -92,36 +111,52 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (result.isExternal());
     }
 
+    /**
+     * Retrieves a program by its ID.
+     * 
+     * @param programId the ID of the program to retrieve
+     * @return the Program object if found, null otherwise
+     */
     @Override
     public Program getProgram(Integer programId) {
         if (programId == null || programId.intValue() <= 0) {
             return null;
         }
 
-        Program program = getHibernateTemplate().get(Program.class, programId);
-
-        return program;
+        return entityManager.find(Program.class, programId);
     }
 
+    /**
+     * Retrieves a program by its ID for appointment view.
+     * 
+     * @param programId the ID of the program to retrieve
+     * @return the Program object if found and has exclusive view set to 'appointment', null otherwise
+     */
     @Override
     public Program getProgramForApptView(Integer programId) {
         if (programId == null || programId <= 0) {
             return null;
         }
-        Program result = null;
-        String queryStr = "FROM Program p WHERE p.id = ? AND p.exclusiveView = 'appointment'";
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, programId);
+
+        String queryStr = "FROM Program p WHERE p.id = ?1 AND p.exclusiveView = 'appointment'";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, programId);
+
+        List<Program> resultList = query.getResultList();
 
         if (log.isDebugEnabled()) {
             log.debug("isCommunityProgram: id=" + programId);
         }
-        if (!rs.isEmpty()) {
-            result = rs.get(0);
-        }
 
-        return result;
+        return resultList.isEmpty() ? null : resultList.get(0);
     }
 
+    /**
+     * Retrieves the name of a program by its ID.
+     * 
+     * @param programId the ID of the program
+     * @return the name of the program if found, null otherwise
+     */
     @Override
     public String getProgramName(Integer programId) {
         Program result = getProgram(programId);
@@ -130,27 +165,36 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (result.getName());
     }
 
+    /**
+     * Retrieves the ID of a program by its name.
+     * 
+     * @param programName the name of the program
+     * @return the ID of the program if found, null otherwise
+     */
     @Override
     public Integer getProgramIdByProgramName(String programName) {
 
         if (programName == null)
             return null;
 
-        @SuppressWarnings("unchecked")
-        List<Program> programs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.name = ? ORDER BY p.id ", programName);
-        if (!programs.isEmpty()) {
-            return programs.get(0).getId();
-        } else {
-            return null;
-        }
+        String queryStr = "FROM Program p WHERE p.name = ?1 ORDER BY p.id";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, programName);
+
+        List<Program> programs = query.getResultList();
+        return programs.isEmpty() ? null : programs.get(0).getId();
     }
 
+    /**
+     * Retrieves all programs.
+     * 
+     * @return a list of all Program objects
+     */
     @Override
     public List<Program> findAll() {
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find("FROM Program p");
-        return rs;
+        String queryStr = "FROM Program p";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        return query.getResultList();
     }
 
     /**
@@ -161,49 +205,70 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getAllPrograms() {
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.type != ? ORDER BY p.name ", Program.COMMUNITY_TYPE);
+        String queryStr = "FROM Program p WHERE p.type != ?1 ORDER BY p.name";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, Program.COMMUNITY_TYPE);
 
         if (log.isDebugEnabled()) {
-            log.debug("getAllPrograms: # of programs: " + rs.size());
+            log.debug("getAllPrograms: # of programs: " + query.getResultList().size());
         }
 
-        return rs;
+        return query.getResultList();
     }
 
+    /**
+     * Retrieves all active programs.
+     * 
+     * @return a list of all active Program objects
+     */
     @Override
     public List<Program> getAllActivePrograms() {
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.programStatus = '" + Program.PROGRAM_STATUS_ACTIVE + "'");
-        return rs;
+        String queryStr = "FROM Program p WHERE p.programStatus = ?1";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, Program.PROGRAM_STATUS_ACTIVE);
+    
+        return query.getResultList();
     }
 
     /**
      * @deprecated 2013-12-09 don't use this anymore use getProgramByType, reason is
      * parameters should never have been "Any"
      */
+    /**
+     * Retrieves programs based on program status, type, and facility ID.
+     * 
+     * @param programStatus the program status filter (can be "Any")
+     * @param type the program type filter (can be "Any")
+     * @param facilityId the facility ID filter (0 for any facility)
+     * @return a list of Program objects matching the specified criteria
+     */
     @Override
     public List<Program> getAllPrograms(String programStatus, String type, int facilityId) {
-        // Session session = getSession();
-        Session session = currentSession();
         try {
-            @SuppressWarnings("unchecked")
-            Criteria c = session.createCriteria(Program.class);
+            StringBuilder queryStr = new StringBuilder("FROM Program p WHERE 1=1");
             if (!"Any".equals(programStatus)) {
-                c.add(Restrictions.eq("programStatus", programStatus));
+                queryStr.append(" AND p.programStatus = :programStatus");
             }
             if (!"Any".equals(type)) {
-                c.add(Restrictions.eq("type", type));
+                queryStr.append(" AND p.type = :type");
             }
             if (facilityId > 0) {
-                c.add(Restrictions.eq("facilityId", facilityId));
+                queryStr.append(" AND p.facilityId = :facilityId");
             }
-            return c.list();
+            TypedQuery<Program> query = entityManager.createQuery(queryStr.toString(), Program.class);
+
+            if (!"Any".equals(programStatus)) {
+                query.setParameter("programStatus", programStatus);
+            }
+            if (!"Any".equals(type)) {
+                query.setParameter("type", type);
+            }
+            if (facilityId > 0) {
+                query.setParameter("facilityId", facilityId);
+            }
+
+            return query.getResultList();
         } finally {
-            // releaseSession(session);
-            //session.close();
 
         }
     }
@@ -216,12 +281,11 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getPrograms() {
-        String queryStr = "FROM Program p WHERE p.type != '" + Program.COMMUNITY_TYPE + "' ORDER BY p.name";
-
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
-
-        return rs;
+        String queryStr = "FROM Program p WHERE p.type != ?1 ORDER BY p.name";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, Program.COMMUNITY_TYPE);
+        
+        return query.getResultList();
     }
 
     /**
@@ -232,93 +296,118 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getActivePrograms() {
-        String queryStr = "FROM Program p WHERE p.type <> '" + Program.COMMUNITY_TYPE + "' and p.programStatus = '"
-                + Program.PROGRAM_STATUS_ACTIVE + "'";
-
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
-
-        return rs;
+        String queryStr = "FROM Program p WHERE p.type <> ?1 AND p.programStatus = ?2";
+    
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, Program.COMMUNITY_TYPE);
+        query.setParameter(2, Program.PROGRAM_STATUS_ACTIVE);
+        
+        return query.getResultList();
     }
 
     /**
-     * @param facilityId is allowed to be null
-     * @return a list of programs in the facility and any programs with no facility
-     * associated
+     * Retrieves programs by facility ID.
+     * 
+     * @param facilityId the ID of the facility (can be null for programs with no associated facility)
+     * @return a list of Program objects associated with the specified facility ID or with no facility
      */
     @Override
     public List<Program> getProgramsByFacilityId(Integer facilityId) {
-        String queryStr = "FROM Program p WHERE (p.facilityId = " + facilityId
-                + " or p.facilityId is null) ORDER BY p.name";
+        String queryStr = "FROM Program p WHERE (p.facilityId = ?1 OR p.facilityId IS NULL) ORDER BY p.name";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, facilityId);
 
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
-
-        return rs;
-    }
-
-    @Override
-    public List<Program> getProgramsByFacilityIdAndFunctionalCentreId(Integer facilityId, String functionalCentreId) {
-        String queryStr = "FROM Program p WHERE p.facilityId = " + facilityId + " and p.functionalCentreId = '"
-                + functionalCentreId + '\'';
-
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
-
-        return rs;
+        return query.getResultList();
     }
 
     /**
-     * @param facilityId is allowed to be null
-     * @return a list of community programs in the facility and any programs with no
-     * facility associated
+     * Retrieves programs by facility ID and functional centre ID.
+     * 
+     * @param facilityId the ID of the facility
+     * @param functionalCentreId the functional centre ID
+     * @return a list of Program objects matching the specified facility ID and functional centre ID
+     */
+    @Override
+    public List<Program> getProgramsByFacilityIdAndFunctionalCentreId(Integer facilityId, String functionalCentreId) {
+        String queryStr = "FROM Program p WHERE p.facilityId = ?1 AND p.functionalCentreId = ?2";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, facilityId);
+        query.setParameter(2, functionalCentreId);
+
+        return query.getResultList();
+    }
+
+    /**
+     * Retrieves community programs by facility ID.
+     * 
+     * @param facilityId the ID of the facility (can be null for programs with no associated facility)
+     * @return a list of community Program objects associated with the specified facility ID or with no facility
      */
     @Override
     public List<Program> getCommunityProgramsByFacilityId(Integer facilityId) {
-        String queryStr = "FROM Program p WHERE (p.facilityId = " + facilityId
-                + " or p.facilityId is null) AND p.type != '" + Program.COMMUNITY_TYPE + "' ORDER BY p.name";
+        String queryStr = "FROM Program p WHERE (p.facilityId = ?1 OR p.facilityId IS NULL) " +
+                      "AND p.type != ?2 ORDER BY p.name";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, facilityId);
+        query.setParameter(2, Program.COMMUNITY_TYPE);
 
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
-
-        return rs;
+        return query.getResultList();
     }
 
     /**
-     * results are ordered by name
-     *
-     * @param facilityId can be null for all, but generally shouldn't be
-     * @param active     can be null for both
+     * Retrieves programs by facility ID, type, and active status.
+     * 
+     * @param facilityId the ID of the facility (can be null for any facility)
+     * @param type the program type
+     * @param active the active status (can be null for both active and inactive)
+     * @return a list of Program objects matching the specified criteria, ordered by name
      */
     @Override
     public List<Program> getProgramsByType(Integer facilityId, String type, Boolean active) {
-        StringBuilder sqlCommand = new StringBuilder("FROM Program p WHERE p.type = '" + type + "'");
+        StringBuilder sqlCommand = new StringBuilder("FROM Program p WHERE p.type = :type");
 
-        if (facilityId != null)
-            sqlCommand.append(" and p.facilityId = " + facilityId);
-        if (active != null)
-            sqlCommand.append(" and p.programStatus='"
-                    + (active ? Program.PROGRAM_STATUS_ACTIVE : Program.PROGRAM_STATUS_INACTIVE) + "'");
+        if (facilityId != null) {
+            sqlCommand.append(" AND p.facilityId = :facilityId");
+        }
+        if (active != null) {
+            sqlCommand.append(" AND p.programStatus = :programStatus");
+        }
 
         sqlCommand.append(" ORDER BY p.name");
 
-        @SuppressWarnings("unchecked")
-        List<Program> list = (List<Program>) getHibernateTemplate().find(sqlCommand.toString());
-        return (list);
+        TypedQuery<Program> query = entityManager.createQuery(sqlCommand.toString(), Program.class);
+        query.setParameter("type", type);
+
+        if (facilityId != null) {
+            query.setParameter("facilityId", facilityId);
+        }
+        if (active != null) {
+            query.setParameter("programStatus", active ? Program.PROGRAM_STATUS_ACTIVE : Program.PROGRAM_STATUS_INACTIVE);
+        }
+
+        return query.getResultList();
     }
 
+    /**
+     * Retrieves programs by gender type.
+     * 
+     * @param genderType the gender type
+     * @return a list of Program objects matching the specified gender type
+     */
     @Override
     public List<Program> getProgramByGenderType(String genderType) {
-        // yeah I know, it's not safe to insert random strings and it's also
-        // inefficient, but unless I fix all the hibernate calls I'm following
-        // convention of
-        // using the hibernate templates and just inserting random strings for now.
-        @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.manOrWoman = '" + genderType + "'");
-        return rs;
+        TypedQuery<Program> query = entityManager.createQuery(
+            "FROM Program p WHERE p.manOrWoman = ?1", Program.class);
+        query.setParameter(1, genderType);
+        return query.getResultList();
     }
 
+    /**
+     * Saves a program.
+     * 
+     * @param program the Program object to save
+     * @throws IllegalArgumentException if the program is null
+     */
     @Override
     public void saveProgram(Program program) {
         if (program == null) {
@@ -326,113 +415,131 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         }
         program.setLastUpdateDate(new Date());
 
-        // Adjusting flush mode
-        Session session = currentSession();
-        FlushMode previousFlushMode = session.getHibernateFlushMode();
-        session.setHibernateFlushMode(FlushMode.COMMIT);
-
-        try {
-            getHibernateTemplate().saveOrUpdate(program);
-        } finally {
-            session.setHibernateFlushMode(previousFlushMode); // Restore the original flush mode
-        }
-        getHibernateTemplate().saveOrUpdate(program);
-
+        entityManager.merge(program); // Use merge to save or update
         if (log.isDebugEnabled()) {
             log.debug("saveProgram: " + program.getId());
         }
     }
 
+    /**
+     * Removes a program by its ID.
+     * 
+     * @param programId the ID of the program to remove
+     * @throws IllegalArgumentException if the programId is null or less than or equal to 0
+     */
     @Override
     public void removeProgram(Integer programId) {
         if (programId == null || programId <= 0) {
             throw new IllegalArgumentException();
         }
-        try {
-            Object program = getHibernateTemplate().load(Program.class, programId);
 
-            getHibernateTemplate().delete(program);
+        Program program = entityManager.find(Program.class, programId);
+        if (program != null) {
+            entityManager.remove(program);
 
             if (log.isDebugEnabled()) {
                 log.debug("deleteProgram: " + programId);
             }
-        } catch (Exception e) {
+        } else {
             MiscUtils.getLogger().warn("Unable to delete program " + programId);
         }
     }
 
+    /**
+     * Searches for programs based on the provided Program object.
+     * 
+     * @param program the Program object containing the search criteria
+     * @return a list of Program objects matching the search criteria
+     * @throws IllegalArgumentException if the program is null
+     */
     @Override
     public List<Program> search(Program program) {
         if (program == null) {
             throw new IllegalArgumentException();
         }
-        // Session session = getSession();
-        Session session = currentSession();
-        Criteria criteria = session.createCriteria(Program.class);
 
-        if (program.getName() != null && program.getName().length() > 0) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Program> query = cb.createQuery(Program.class);
+        Root<Program> root = query.from(Program.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (program.getName() != null && !program.getName().isEmpty()) {
             String programName = StringEscapeUtils.escapeSql(program.getName());
-            String sql = "";
-            sql = "((LEFT(SOUNDEX(name),4) = LEFT(SOUNDEX('" + programName + "'),4))" + " " + "OR (name like '" + "%"
-                    + programName + "%'))";
-            criteria.add(Restrictions.sqlRestriction(sql));
+            
+            // Create SOUNDEX expression for the program name
+            Expression<String> soundexProgramName = cb.function("SOUNDEX", String.class, cb.literal(programName));
+            Expression<String> soundexName = cb.function("SOUNDEX", String.class, root.get("name"));
+            
+            Predicate namePredicate = cb.or(
+                cb.like(root.get("name"), "%" + programName + "%"),
+                cb.equal(cb.function("LEFT", String.class, soundexName), 
+                         cb.function("LEFT", String.class, soundexProgramName))
+            );
+            predicates.add(namePredicate);
         }
-
-        if (program.getType() != null && program.getType().length() > 0) {
-            criteria.add(Expression.eq("type", program.getType()));
+    
+        // Filter by type
+        if (program.getType() != null && !program.getType().isEmpty()) {
+            predicates.add(cb.equal(root.get("type"), program.getType()));
         }
-
-        if (program.getType() == null || program.getType().equals("") || !program.getType().equals("community")) {
-            criteria.add(Expression.ne("type", "community"));
+    
+        if (program.getType() == null || program.getType().isEmpty() || !program.getType().equals("community")) {
+            predicates.add(cb.notEqual(root.get("type"), "community"));
         }
-
-        criteria.add(Expression.eq("programStatus", Program.PROGRAM_STATUS_ACTIVE));
-
-        if (program.getManOrWoman() != null && program.getManOrWoman().length() > 0) {
-            criteria.add(Expression.eq("manOrWoman", program.getManOrWoman()));
+    
+        predicates.add(cb.equal(root.get("programStatus"), Program.PROGRAM_STATUS_ACTIVE));
+    
+        // Filter by manOrWoman
+        if (program.getManOrWoman() != null && !program.getManOrWoman().isEmpty()) {
+            predicates.add(cb.equal(root.get("manOrWoman"), program.getManOrWoman()));
         }
-
+    
+        // Other filters
         if (program.isTransgender()) {
-            criteria.add(Expression.eq("transgender", true));
+            predicates.add(cb.isTrue(root.get("transgender")));
         }
-
+    
         if (program.isFirstNation()) {
-            criteria.add(Expression.eq("firstNation", true));
+            predicates.add(cb.isTrue(root.get("firstNation")));
         }
-
+    
         if (program.isBedProgramAffiliated()) {
-            criteria.add(Expression.eq("bedProgramAffiliated", true));
+            predicates.add(cb.isTrue(root.get("bedProgramAffiliated")));
         }
-
+    
         if (program.isAlcohol()) {
-            criteria.add(Expression.eq("alcohol", true));
+            predicates.add(cb.isTrue(root.get("alcohol")));
         }
-
-        if (program.getAbstinenceSupport() != null && program.getAbstinenceSupport().length() > 0) {
-            criteria.add(Expression.eq("abstinenceSupport", program.getAbstinenceSupport()));
+    
+        if (program.getAbstinenceSupport() != null && !program.getAbstinenceSupport().isEmpty()) {
+            predicates.add(cb.equal(root.get("abstinenceSupport"), program.getAbstinenceSupport()));
         }
-
+    
         if (program.isPhysicalHealth()) {
-            criteria.add(Expression.eq("physicalHealth", true));
+            predicates.add(cb.isTrue(root.get("physicalHealth")));
         }
-
+    
         if (program.isHousing()) {
-            criteria.add(Expression.eq("housing", true));
+            predicates.add(cb.isTrue(root.get("housing")));
         }
-
+    
         if (program.isMentalHealth()) {
-            criteria.add(Expression.eq("mentalHealth", true));
+            predicates.add(cb.isTrue(root.get("mentalHealth")));
         }
-        criteria.addOrder(Order.asc("name"));
-
-        List results = new ArrayList();
+    
+        // Combine all predicates into the query
+        query.select(root).where(predicates.toArray(new Predicate[0])).orderBy(cb.asc(root.get("name")));
+    
+        // Create the query and get the results
+        TypedQuery<Program> typedQuery = entityManager.createQuery(query);
+        List<Program> results = new ArrayList<>();
         try {
-            results = criteria.list();
-        } finally {
-            // this.releaseSession(session);
-            //session.close();
+            results = typedQuery.getResultList();
+        } catch (Exception e) {
+            log.error("Error while searching programs", e);
         }
-
+    
         if (log.isDebugEnabled()) {
             log.debug("search: # results: " + results.size());
         }
@@ -440,6 +547,14 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return results;
     }
 
+    /**
+     * Searches for programs based on the provided Program object and facility ID.
+     * 
+     * @param program the Program object containing the search criteria
+     * @param facilityId the ID of the facility to search within
+     * @return a list of Program objects matching the search criteria and facility ID
+     * @throws IllegalArgumentException if the program or facilityId is null
+     */
     @Override
     public List<Program> searchByFacility(Program program, Integer facilityId) {
         if (program == null) {
@@ -449,91 +564,101 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
             throw new IllegalArgumentException();
         }
 
-        boolean isOracle = OscarProperties.getInstance().getDbType().equals("oracle");
-        // Session session = getSession();
-        Session session = currentSession();
-        Criteria criteria = session.createCriteria(Program.class);
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Program> query = cb.createQuery(Program.class);
+        Root<Program> root = query.from(Program.class);
 
-        if (program.getName() != null && program.getName().length() > 0) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        // Filter by name
+        if (program.getName() != null && !program.getName().isEmpty()) {
             String programName = StringEscapeUtils.escapeSql(program.getName());
-            String sql = "";
-            if (isOracle) {
-                sql = "((LEFT(SOUNDEX(name),4) = LEFT(SOUNDEX('" + programName + "'),4)))";
-                criteria.add(Restrictions.or(Restrictions.ilike("name", "%" + programName + "%"),
-                        Restrictions.sqlRestriction(sql)));
-            } else {
-                sql = "((LEFT(SOUNDEX(name),4) = LEFT(SOUNDEX('" + programName + "'),4))" + " " + "OR (name like '"
-                        + "%" + programName + "%'))";
-                criteria.add(Restrictions.sqlRestriction(sql));
-            }
+            // Create SOUNDEX expression for the program name
+            Expression<String> soundexProgramName = cb.function("SOUNDEX", String.class, cb.literal(programName));
+            Expression<String> soundexName = cb.function("SOUNDEX", String.class, root.get("name"));
+            
+            Predicate namePredicate = cb.or(
+                cb.like(root.get("name"), "%" + programName + "%"),
+                cb.equal(cb.function("LEFT", String.class, soundexName), 
+                        cb.function("LEFT", String.class, soundexProgramName))
+            );
+            predicates.add(namePredicate);
         }
 
-        if (program.getType() != null && program.getType().length() > 0) {
-            criteria.add(Expression.eq("type", program.getType()));
+        // Filter by type
+        if (program.getType() != null && !program.getType().isEmpty()) {
+            predicates.add(cb.equal(root.get("type"), program.getType()));
         }
 
-        if (program.getType() == null || program.getType().equals("")
-                || !program.getType().equals(Program.COMMUNITY_TYPE)) {
-            criteria.add(Expression.ne("type", Program.COMMUNITY_TYPE));
+        if (program.getType() == null || program.getType().isEmpty() || !program.getType().equals(Program.COMMUNITY_TYPE)) {
+            predicates.add(cb.notEqual(root.get("type"), Program.COMMUNITY_TYPE));
         }
 
-        criteria.add(Expression.eq("programStatus", Program.PROGRAM_STATUS_ACTIVE));
+        predicates.add(cb.equal(root.get("programStatus"), Program.PROGRAM_STATUS_ACTIVE));
 
-        if (program.getManOrWoman() != null && program.getManOrWoman().length() > 0) {
-            criteria.add(Expression.eq("manOrWoman", program.getManOrWoman()));
+        // Filter by manOrWoman
+        if (program.getManOrWoman() != null && !program.getManOrWoman().isEmpty()) {
+            predicates.add(cb.equal(root.get("manOrWoman"), program.getManOrWoman()));
         }
 
+        // Other filters
         if (program.isTransgender()) {
-            criteria.add(Expression.eq("transgender", true));
+            predicates.add(cb.isTrue(root.get("transgender")));
         }
 
         if (program.isFirstNation()) {
-            criteria.add(Expression.eq("firstNation", true));
+            predicates.add(cb.isTrue(root.get("firstNation")));
         }
 
         if (program.isBedProgramAffiliated()) {
-            criteria.add(Expression.eq("bedProgramAffiliated", true));
+            predicates.add(cb.isTrue(root.get("bedProgramAffiliated")));
         }
 
         if (program.isAlcohol()) {
-            criteria.add(Expression.eq("alcohol", true));
+            predicates.add(cb.isTrue(root.get("alcohol")));
         }
 
-        if (program.getAbstinenceSupport() != null && program.getAbstinenceSupport().length() > 0) {
-            criteria.add(Expression.eq("abstinenceSupport", program.getAbstinenceSupport()));
+        if (program.getAbstinenceSupport() != null && !program.getAbstinenceSupport().isEmpty()) {
+            predicates.add(cb.equal(root.get("abstinenceSupport"), program.getAbstinenceSupport()));
         }
 
         if (program.isPhysicalHealth()) {
-            criteria.add(Expression.eq("physicalHealth", true));
+            predicates.add(cb.isTrue(root.get("physicalHealth")));
         }
 
         if (program.isHousing()) {
-            criteria.add(Expression.eq("housing", true));
+            predicates.add(cb.isTrue(root.get("housing")));
         }
 
         if (program.isMentalHealth()) {
-            criteria.add(Expression.eq("mentalHealth", true));
+            predicates.add(cb.isTrue(root.get("mentalHealth")));
         }
 
-        criteria.add(Expression.eq("facilityId", facilityId));
+        // Filter by facilityId
+        predicates.add(cb.equal(root.get("facilityId"), facilityId));
 
-        criteria.addOrder(Order.asc("name"));
+        // Combine all predicates into the query
+        query.select(root).where(predicates.toArray(new Predicate[0])).orderBy(cb.asc(root.get("name")));
 
-        List results = new ArrayList();
+        // Create the query and get the results
+        TypedQuery<Program> typedQuery = entityManager.createQuery(query);
+        List<Program> results = new ArrayList<>();
         try {
-            results = criteria.list();
-        } finally {
-            // releaseSession(session);
-            //session.close();
+            results = typedQuery.getResultList();
+        } catch (Exception e) {
+            log.error("Error while searching programs by facility", e);
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("search: # results: " + results.size());
+            log.debug("searchByFacility: # results: " + results.size());
         }
 
         return results;
     }
 
+    /**
+     * Resets the holding tank by setting the holdingTank flag to false for all programs.
+     */
     @Override
     public void resetHoldingTank() {
         List<Program> programs = this.getAllPrograms();
@@ -550,13 +675,17 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         }
     }
 
+    /**
+     * Retrieves the holding tank program.
+     * 
+     * @return the Program object representing the holding tank program, or null if not found
+     */
     @Override
     public Program getHoldingTankProgram() {
         Program result = null;
 
-        @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate()
-                .find("from Program p where p.holdingTank = true");
+        TypedQuery<Program> query = entityManager.createQuery("SELECT p FROM Program p WHERE p.holdingTank = true", Program.class);
+        List<Program> results = query.getResultList();
 
         if (!results.isEmpty()) {
             result = results.get(0);
@@ -570,20 +699,43 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return result;
     }
 
+    /**
+     * Checks if a program exists by its ID.
+     * 
+     * @param programId the ID of the program to check
+     * @return true if the program exists, false otherwise
+     */
     @Override
     public boolean programExists(Integer programId) {
         return (getProgram(programId) != null);
     }
 
+    /**
+     * Retrieves the linked service programs for a bed program and client.
+     * 
+     * @param bedProgramId the ID of the bed program
+     * @param clientId the ID of the client
+     * @return a list of Program objects representing the linked service programs
+     */
     public List<Program> getLinkedServicePrograms(Integer bedProgramId, Integer clientId) {
-        @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) this.getHibernateTemplate().find(
-                "select p from Admission a,Program p where a.programId = p.id and p.type='" + Program.SERVICE_TYPE
-                        + "' and  p.bedProgramLinkId = ? and a.clientId=?",
-                new Object[]{bedProgramId, clientId});
-        return results;
+        String queryStr = "SELECT p FROM Admission a JOIN Program p ON a.programId = p.id "
+                 + "WHERE p.type = ?1 AND p.bedProgramLinkId = ?2 AND a.clientId = ?3";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, Program.SERVICE_TYPE);
+        query.setParameter(2, bedProgramId);
+        query.setParameter(3, clientId);
+
+        return query.getResultList();
     }
 
+    /**
+     * Checks if two programs are in the same facility.
+     * 
+     * @param programId1 the ID of the first program
+     * @param programId2 the ID of the second program
+     * @return true if the programs are in the same facility, false otherwise
+     * @throws IllegalArgumentException if either programId is null or less than or equal to 0
+     */
     @Override
     public boolean isInSameFacility(Integer programId1, Integer programId2) {
         if (programId1 == null || programId1 <= 0) {
@@ -603,14 +755,21 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return (p1.getFacilityId() == p2.getFacilityId());
     }
 
+    /**
+     * Retrieves a program by its site-specific field value.
+     * 
+     * @param value the value of the site-specific field
+     * @return the Program object if found, null otherwise
+     */
     @Override
     public Program getProgramBySiteSpecificField(String value) {
         Program result = null;
 
-        @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate()
-                .find("from Program p where p.siteSpecificField = ?", new Object[]{value});
+        String queryStr = "SELECT p FROM Program p WHERE p.siteSpecificField = ?1";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, value);
 
+        List<Program> results = query.getResultList();
         if (!results.isEmpty()) {
             result = results.get(0);
         }
@@ -618,14 +777,21 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return result;
     }
 
+    /**
+     * Retrieves a program by its name.
+     * 
+     * @param value the name of the program
+     * @return the Program object if found, null otherwise
+     */
     @Override
     public Program getProgramByName(String value) {
         Program result = null;
 
-        @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate().find("from Program p where p.name = ?0",
-                new Object[]{value});
+        String queryStr = "SELECT p FROM Program p WHERE p.name = ?1";
+        TypedQuery<Program> query = entityManager.createQuery(queryStr, Program.class);
+        query.setParameter(1, value);
 
+        List<Program> results = query.getResultList();
         if (!results.isEmpty()) {
             result = results.get(0);
         }
@@ -633,31 +799,50 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         return result;
     }
 
+    /**
+     * Retrieves the IDs of programs added or updated since a specific time for a given facility.
+     * 
+     * @param facilityId the ID of the facility
+     * @param date the reference date
+     * @return a list of program IDs added or updated since the specified time
+     */
     @Override
     public List<Integer> getRecordsAddedAndUpdatedSinceTime(Integer facilityId, Date date) {
-        @SuppressWarnings("unchecked")
-        List<Integer> programs = (List<Integer>) getHibernateTemplate().find(
-                "select distinct p.id From Program p where p.facilityId = ? and p.lastUpdateDate > ?  ", facilityId,
-                date);
+        String queryStr = "SELECT DISTINCT p.id FROM Program p WHERE p.facilityId = ?1 AND p.lastUpdateDate > ?2";
+        TypedQuery<Integer> query = entityManager.createQuery(queryStr, Integer.class);
+        query.setParameter(1, facilityId);
+        query.setParameter(2, date);
 
-        return programs;
+        return query.getResultList();
     }
 
+    /**
+     * Retrieves the IDs of programs associated with a specific facility.
+     * 
+     * @param facilityId the ID of the facility
+     * @return a list of program IDs associated with the specified facility
+     */
     @Override
     public List<Integer> getRecordsByFacilityId(Integer facilityId) {
-        @SuppressWarnings("unchecked")
-        List<Integer> programs = (List<Integer>) getHibernateTemplate()
-                .find("select distinct p.id From Program p where p.facilityId = ? ", facilityId);
+        String queryStr = "SELECT DISTINCT p.id FROM Program p WHERE p.facilityId = ?1";
+        TypedQuery<Integer> query = entityManager.createQuery(queryStr, Integer.class);
+        query.setParameter(1, facilityId);
 
-        return programs;
+        return query.getResultList();
     }
 
+    /**
+     * Retrieves the provider numbers of providers added or updated since a specific time.
+     * 
+     * @param date the reference date
+     * @return a list of provider numbers added or updated since the specified time
+     */
     @Override
     public List<String> getRecordsAddedAndUpdatedSinceTime(Date date) {
-        @SuppressWarnings("unchecked")
-        List<String> providers = (List<String>) getHibernateTemplate()
-                .find("select distinct p.ProviderNo From Provider p where p.lastUpdateDate > ? ", date);
+        String queryStr = "SELECT DISTINCT p.providerNo FROM Provider p WHERE p.lastUpdateDate > ?1";        
+        TypedQuery<String> query = entityManager.createQuery(queryStr, String.class);
+        query.setParameter(1, date);
 
-        return providers;
+        return query.getResultList();
     }
 }

--- a/src/main/java/org/oscarehr/PMmodule/model/Program.java
+++ b/src/main/java/org/oscarehr/PMmodule/model/Program.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 /**
  * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
  * This software is published under the GPL GNU General Public License.
@@ -23,16 +22,24 @@
 
 package org.oscarehr.PMmodule.model;
 
-import java.io.Serializable;
-import java.util.Date;
-import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 
+import java.util.Date;
 import com.quatro.model.LookupCodeValue;
+import org.oscarehr.common.model.AbstractModel;
 
 /**
  * This is the object class that relates to the program table. Any customizations belong here.
+ * 
+ * Entity implementation class for Entity: Program
+ * Represents a program in the system.
  */
-public class Program implements Serializable {
+@Entity
+@Table(name = "program")
+public class Program extends AbstractModel<Integer> {
     public static final Integer DEFAULT_COMMUNITY_PROGRAM_ID = new Integer(10010);
 
     public static final String EXTERNAL_TYPE = "external";
@@ -49,6 +56,8 @@ public class Program implements Serializable {
 
     private int hashCode = Integer.MIN_VALUE;// primary key
 
+    @Id
+    @Column(name = "id")
     private Integer id;
 
     private boolean userDefined = true;
@@ -117,7 +126,20 @@ public class Program implements Serializable {
     private String vacancyTemplateName;
 
     /**
-     * Constructor for required fields
+     * Constructor for required fields.
+     * 
+     * @param id the program ID
+     * @param isUserDefined flag indicating if program is user defined
+     * @param maxAllowed maximum number of clients allowed in the program
+     * @param address the program address
+     * @param phone the program phone number
+     * @param fax the program fax number
+     * @param url the program URL
+     * @param email the program email
+     * @param emergencyNumber the program emergency contact number
+     * @param name the program name
+     * @param holdingTank flag indicating if this is a holding tank program
+     * @param programStatus the status of the program (active/inactive)
      */
     public Program(Integer id, boolean isUserDefined, Integer maxAllowed, String address, String phone, String fax, String url, String email, String emergencyNumber, String name, boolean holdingTank, String programStatus) {
 
@@ -192,7 +214,10 @@ public class Program implements Serializable {
         this.capacity_space = capacity_space;
     }
 
-    // constructors
+    /**
+     * Default no-arg constructor.
+     * Required by JPA.
+     */
     public Program() {
         // no arg constructor for JPA
     }
@@ -222,342 +247,551 @@ public class Program implements Serializable {
     }
 
     /**
-     * Constructor for primary key
+     * Constructor for primary key.
+     * 
+     * @param id the program ID
      */
     public Program(Integer id) {
         this.setId(id);
     }
 
+    /**
+     * Checks if this program is user defined.
+     * 
+     * @return true if user defined, false otherwise
+     */
     public boolean isUserDefined() {
         return userDefined;
     }
 
+    /**
+     * Sets whether this program is user defined.
+     * 
+     * @param userDefined true if user defined, false otherwise
+     */
     public void setUserDefined(boolean userDefined) {
         this.userDefined = userDefined;
     }
 
+    /**
+     * Checks if this program is active.
+     * 
+     * @return true if the program status is active, false otherwise
+     */
     public boolean isActive() {
         return PROGRAM_STATUS_ACTIVE.equals(programStatus);
     }
 
+    /**
+     * Checks if this program is full (number of members equals or exceeds the maximum allowed).
+     * 
+     * @return true if the program is full, false otherwise
+     */
     public boolean isFull() {
         return getNumOfMembers().intValue() >= getMaxAllowed().intValue();
     }
 
+    /**
+     * Checks if this is an external program.
+     * 
+     * @return true if the program type is "external", false otherwise
+     */
     public boolean isExternal() {
         return EXTERNAL_TYPE.equalsIgnoreCase(getType());
     }
 
+    /**
+     * Checks if this is a bed program.
+     * 
+     * @return true if the program type is "Bed", false otherwise
+     */
     public boolean isBed() {
         return BED_TYPE.equalsIgnoreCase(getType());
     }
 
+    /**
+     * Checks if this is a community program.
+     * 
+     * @return true if the program type is "community", false otherwise
+     */
     public boolean isCommunity() {
         return COMMUNITY_TYPE.equalsIgnoreCase(getType());
     }
 
+    /**
+     * Checks if this is a service program.
+     * 
+     * @return true if the program type is "Service", false otherwise
+     */
     public boolean isService() {
         return SERVICE_TYPE.equalsIgnoreCase(getType());
     }
 
+    /**
+     * Checks if this is a holding tank program.
+     * 
+     * @return true if this is a holding tank program, false otherwise
+     */
     public boolean getHoldingTank() {
         return isHoldingTank();
     }
 
+    /**
+     * Gets the ID of this program.
+     * 
+     * @return the program ID
+     */
     public Integer getId() {
         return id;
     }
 
+    /**
+     * Sets the ID of this program.
+     * 
+     * @param id the program ID to set
+     */
     public void setId(Integer id) {
         this.id = id;
         this.hashCode = Integer.MIN_VALUE;
     }
 
     /**
-     * Return the value associated with the column: numOfMembers
+     * Gets the number of members in this program.
+     * 
+     * @return the number of members
      */
     public Integer getNumOfMembers() {
         return numOfMembers;
     }
 
     /**
-     * Set the value related to the column: numOfMembers
-     *
-     * @param numOfMembers the numOfMembers value
+     * Sets the number of members in this program.
+     * 
+     * @param numOfMembers the number of members to set
      */
     public void setNumOfMembers(Integer numOfMembers) {
         this.numOfMembers = numOfMembers;
     }
 
     /**
-     * Return the value associated with the column: queueSize
+     * Gets the queue size for this program.
+     * 
+     * @return the queue size
      */
     public Integer getQueueSize() {
         return queueSize;
     }
 
     /**
-     * Set the value related to the column: queueSize
-     *
-     * @param queueSize the queueSize value
+     * Sets the queue size for this program.
+     * 
+     * @param queueSize the queue size to set
      */
     public void setQueueSize(Integer queueSize) {
         this.queueSize = queueSize;
     }
 
+    /**
+     * Gets the maximum number of clients allowed in this program.
+     * 
+     * @return the maximum allowed
+     */
     public Integer getMaxAllowed() {
         return maxAllowed;
     }
 
+    /**
+     * Sets the maximum number of clients allowed in this program.
+     * 
+     * @param maxAllowed the maximum allowed to set
+     */
     public void setMaxAllowed(Integer maxAllowed) {
         this.maxAllowed = maxAllowed;
     }
 
     /**
-     * Return the value associated with the column: type
+     * Gets the type of this program.
+     * 
+     * @return the program type
      */
     public String getType() {
         return type;
     }
 
     /**
-     * Set the value related to the column: type
-     *
-     * @param type the type value
+     * Sets the type of this program.
+     * 
+     * @param type the program type to set
      */
     public void setType(String type) {
         this.type = type;
     }
 
+    /**
+     * Gets the description of this program.
+     * 
+     * @return the program description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Sets the description of this program.
+     * 
+     * @param description the program description to set
+     */
     public void setDescription(String description) {
         this.description = description;
     }
 
     /**
-     * Return the value associated with the column: address
+     * Gets the address of this program.
+     * 
+     * @return the program address
      */
     public String getAddress() {
         return address;
     }
 
     /**
-     * Set the value related to the column: address
-     *
-     * @param address the address value
+     * Sets the address of this program.
+     * 
+     * @param address the program address to set
      */
     public void setAddress(String address) {
         this.address = address;
     }
 
     /**
-     * Return the value associated with the column: phone
+     * Gets the phone number of this program.
+     * 
+     * @return the program phone number
      */
     public String getPhone() {
         return phone;
     }
 
     /**
-     * Set the value related to the column: phone
-     *
-     * @param phone the phone value
+     * Sets the phone number of this program.
+     * 
+     * @param phone the program phone number to set
      */
     public void setPhone(String phone) {
         this.phone = phone;
     }
 
     /**
-     * Return the value associated with the column: fax
+     * Gets the fax number of this program.
+     * 
+     * @return the program fax number
      */
     public String getFax() {
         return fax;
     }
 
     /**
-     * Set the value related to the column: fax
-     *
-     * @param fax the fax value
+     * Sets the fax number of this program.
+     * 
+     * @param fax the program fax number to set
      */
     public void setFax(String fax) {
         this.fax = fax;
     }
 
     /**
-     * Return the value associated with the column: url
+     * Gets the URL of this program.
+     * 
+     * @return the program URL
      */
     public String getUrl() {
         return url;
     }
 
     /**
-     * Set the value related to the column: url
-     *
-     * @param url the url value
+     * Sets the URL of this program.
+     * 
+     * @param url the program URL to set
      */
     public void setUrl(String url) {
         this.url = url;
     }
 
     /**
-     * Return the value associated with the column: email
+     * Gets the email address of this program.
+     * 
+     * @return the program email address
      */
     public String getEmail() {
         return email;
     }
 
     /**
-     * Set the value related to the column: email
-     *
-     * @param email the email value
+     * Sets the email address of this program.
+     * 
+     * @param email the program email address to set
      */
     public void setEmail(String email) {
         this.email = email;
     }
 
+    /**
+     * Gets the emergency contact number of this program.
+     * 
+     * @return the program emergency contact number
+     */
     public String getEmergencyNumber() {
         return emergencyNumber;
     }
 
+    /**
+     * Sets the emergency contact number of this program.
+     * 
+     * @param emergencyNumber the program emergency contact number to set
+     */
     public void setEmergencyNumber(String emergencyNumber) {
         this.emergencyNumber = emergencyNumber;
     }
 
     /**
-     * Return the value associated with the column: location
+     * Gets the location of this program.
+     * 
+     * @return the program location
      */
     public String getLocation() {
         return location;
     }
 
     /**
-     * Set the value related to the column: location
-     *
-     * @param location the location value
+     * Sets the location of this program.
+     * 
+     * @param location the program location to set
      */
     public void setLocation(String location) {
         this.location = location;
     }
 
     /**
-     * Return the value associated with the column: name
+     * Gets the name of this program.
+     * 
+     * @return the program name
      */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the JavaScript-escaped name of this program.
+     * 
+     * @return the JavaScript-escaped program name
+     */
     public String getNameJs() {
         return oscar.Misc.getStringJs(name);
     }
 
     /**
-     * Set the value related to the column: name
-     *
-     * @param name the name value
+     * Sets the name of this program.
+     * 
+     * @param name the program name to set
      */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Checks if this is a holding tank program.
+     * 
+     * @return true if this is a holding tank program, false otherwise
+     */
     public boolean isHoldingTank() {
         return holdingTank;
     }
 
+    /**
+     * Sets whether this is a holding tank program.
+     * 
+     * @param holdingTank true if this is a holding tank program, false otherwise
+     */
     public void setHoldingTank(boolean holdingTank) {
         this.holdingTank = holdingTank;
     }
 
+    /**
+     * Checks if batch admission is allowed for this program.
+     * 
+     * @return true if batch admission is allowed, false otherwise
+     */
     public boolean isAllowBatchAdmission() {
         return allowBatchAdmission;
     }
 
+    /**
+     * Sets whether batch admission is allowed for this program.
+     * 
+     * @param allowBatchAdmission true if batch admission is allowed, false otherwise
+     */
     public void setAllowBatchAdmission(boolean allowBatchAdmission) {
         this.allowBatchAdmission = allowBatchAdmission;
     }
 
+    /**
+     * Checks if batch discharge is allowed for this program.
+     * 
+     * @return true if batch discharge is allowed, false otherwise
+     */
     public boolean isAllowBatchDischarge() {
         return allowBatchDischarge;
     }
 
+    /**
+     * Sets whether batch discharge is allowed for this program.
+     * 
+     * @param allowBatchDischarge true if batch discharge is allowed, false otherwise
+     */
     public void setAllowBatchDischarge(boolean allowBatchDischarge) {
         this.allowBatchDischarge = allowBatchDischarge;
     }
 
     /**
-     * Return the value associated with the column: hic
+     * Checks if this program requires a health insurance card (HIC).
+     * 
+     * @return true if a HIC is required, false otherwise
      */
     public boolean isHic() {
         return hic;
     }
 
     /**
-     * Set the value related to the column: hic
-     *
-     * @param hic the hic value
+     * Sets whether this program requires a health insurance card (HIC).
+     * 
+     * @param hic true if a HIC is required, false otherwise
      */
     public void setHic(boolean hic) {
         this.hic = hic;
     }
 
+    /**
+     * Gets the status of this program.
+     * 
+     * @return the program status
+     */
     public String getProgramStatus() {
         return programStatus;
     }
 
     /**
-     * Set the value related to the column: program_status
-     *
-     * @param programStatus the program_status value
+     * Sets the status of this program.
+     * 
+     * @param programStatus the program status to set
      */
     public void setProgramStatus(String programStatus) {
         this.programStatus = programStatus;
     }
 
+    /**
+     * Gets the intake program associated with this program.
+     * 
+     * @return the intake program ID
+     */
     public Integer getIntakeProgram() {
         return intakeProgram;
     }
 
+    /**
+     * Sets the intake program associated with this program.
+     * 
+     * @param intakeProgram the intake program ID to set
+     */
     public void setIntakeProgram(Integer intakeProgram) {
         this.intakeProgram = intakeProgram;
     }
 
+    /**
+     * Gets the ID of the bed program linked to this program.
+     * 
+     * @return the bed program link ID
+     */
     public Integer getBedProgramLinkId() {
         return bedProgramLinkId;
     }
 
+    /**
+     * Sets the ID of the bed program linked to this program.
+     * 
+     * @param bedProgramLinkId the bed program link ID to set
+     */
     public void setBedProgramLinkId(Integer bedProgramLinkId) {
         this.bedProgramLinkId = bedProgramLinkId;
     }
 
+    /**
+     * Gets the abstinence support offered by this program.
+     * 
+     * @return the abstinence support description
+     */
     public String getAbstinenceSupport() {
         return abstinenceSupport;
     }
 
+    /**
+     * Sets the abstinence support offered by this program.
+     * 
+     * @param abstinenceSupport the abstinence support description to set
+     */
     public void setAbstinenceSupport(String abstinenceSupport) {
         this.abstinenceSupport = abstinenceSupport;
     }
 
+    /**
+     * Checks if this program addresses alcohol addiction.
+     * 
+     * @return true if the program addresses alcohol addiction, false otherwise
+     */
     public boolean isAlcohol() {
         return alcohol;
     }
 
+    /**
+     * Sets whether this program addresses alcohol addiction.
+     * 
+     * @param alcohol true if the program addresses alcohol addiction, false otherwise
+     */
     public void setAlcohol(boolean alcohol) {
         this.alcohol = alcohol;
     }
 
+    /**
+     * Checks if this program is affiliated with a bed program.
+     * 
+     * @return true if affiliated with a bed program, false otherwise
+     */
     public boolean isBedProgramAffiliated() {
         return bedProgramAffiliated;
     }
 
+    /**
+     * Sets whether this program is affiliated with a bed program.
+     * 
+     * @param bedProgramAffiliated true if affiliated with a bed program, false otherwise
+     */
     public void setBedProgramAffiliated(boolean bedProgramAffiliated) {
         this.bedProgramAffiliated = bedProgramAffiliated;
     }
 
+    /**
+     * Checks if this program serves First Nations communities.
+     * 
+     * @return true if the program serves First Nations, false otherwise
+     */
     public boolean isFirstNation() {
         return firstNation;
     }
 
+    /**
+     * Sets whether this program serves First Nations communities.
+     * 
+     * @param firstNation true if the program serves First Nations, false otherwise
+     */
     public void setFirstNation(boolean firstNation) {
         this.firstNation = firstNation;
     }
@@ -570,54 +804,119 @@ public class Program implements Serializable {
         this.hashCode = hashCode;
     }
 
+    /**
+     * Checks if this program provides housing support.
+     * 
+     * @return true if the program provides housing support, false otherwise
+     */
     public boolean isHousing() {
         return housing;
     }
 
+    /**
+     * Sets whether this program provides housing support.
+     * 
+     * @param housing true if the program provides housing support, false otherwise
+     */
     public void setHousing(boolean housing) {
         this.housing = housing;
     }
 
+    /**
+     * Gets the gender served by this program (man, woman, or both).
+     * 
+     * @return the gender served by the program
+     */
     public String getManOrWoman() {
         return manOrWoman;
     }
 
+    /**
+     * Sets the gender served by this program (man, woman, or both).
+     * 
+     * @param manOrWoman the gender served by the program
+     */
     public void setManOrWoman(String manOrWoman) {
         this.manOrWoman = manOrWoman;
     }
 
+    /**
+     * Checks if this program addresses mental health.
+     * 
+     * @return true if the program addresses mental health, false otherwise
+     */
     public boolean isMentalHealth() {
         return mentalHealth;
     }
 
+    /**
+     * Sets whether this program addresses mental health.
+     * 
+     * @param mentalHealth true if the program addresses mental health, false otherwise
+     */
     public void setMentalHealth(boolean mentalHealth) {
         this.mentalHealth = mentalHealth;
     }
 
+    /**
+     * Checks if this program addresses physical health.
+     * 
+     * @return true if the program addresses physical health, false otherwise
+     */
     public boolean isPhysicalHealth() {
         return physicalHealth;
     }
 
+    /**
+     * Sets whether this program addresses physical health.
+     * 
+     * @param physicalHealth true if the program addresses physical health, false otherwise
+     */
     public void setPhysicalHealth(boolean physicalHealth) {
         this.physicalHealth = physicalHealth;
     }
 
+    /**
+     * Checks if this program serves transgender individuals.
+     * 
+     * @return true if the program serves transgender individuals, false otherwise
+     */
     public boolean isTransgender() {
         return transgender;
     }
 
+    /**
+     * Sets whether this program serves transgender individuals.
+     * 
+     * @param transgender true if the program serves transgender individuals, false otherwise
+     */
     public void setTransgender(boolean transgender) {
         this.transgender = transgender;
     }
 
+    /**
+     * Gets the exclusive view setting for this program.
+     * 
+     * @return the exclusive view setting
+     */
     public String getExclusiveView() {
         return exclusiveView;
     }
 
+    /**
+     * Sets the exclusive view setting for this program.
+     * 
+     * @param exclusiveView the exclusive view setting to set
+     */
     public void setExclusiveView(String exclusiveView) {
         this.exclusiveView = exclusiveView;
     }
 
+    /**
+     * Gets the minimum age for this program.
+     * 
+     * @return the minimum age, or the default minimum age if not set
+     */
     public Integer getAgeMin() {
         if (this.ageMin != null) {
             return ageMin;
@@ -626,10 +925,20 @@ public class Program implements Serializable {
         return this.MIN_AGE;
     }
 
+    /**
+     * Sets the minimum age for this program.
+     * 
+     * @param ageMin the minimum age to set
+     */
     public void setAgeMin(Integer ageMin) {
         this.ageMin = ageMin;
     }
 
+    /**
+     * Gets the maximum age for this program.
+     * 
+     * @return the maximum age, or the default maximum age if not set
+     */
     public Integer getAgeMax() {
         if (this.ageMax != null) {
             return ageMax;
@@ -637,18 +946,38 @@ public class Program implements Serializable {
         return this.MAX_AGE;
     }
 
+    /**
+     * Sets the maximum age for this program.
+     * 
+     * @param ageMax the maximum age to set
+     */
     public void setAgeMax(Integer ageMax) {
         this.ageMax = ageMax;
     }
 
+    /**
+     * Gets the maximum number of service restriction days for this program.
+     * 
+     * @return the maximum service restriction days
+     */
     public Integer getMaximumServiceRestrictionDays() {
         return maximumServiceRestrictionDays;
     }
 
+    /**
+     * Sets the maximum number of service restriction days for this program.
+     * 
+     * @param maximumServiceRestrictionDays the maximum service restriction days to set
+     */
     public void setMaximumServiceRestrictionDays(Integer maximumServiceRestrictionDays) {
         this.maximumServiceRestrictionDays = maximumServiceRestrictionDays;
     }
 
+    /**
+     * Gets the default number of service restriction days for this program.
+     * 
+     * @return the default service restriction days, or the program default if not set or invalid
+     */
     public Integer getDefaultServiceRestrictionDays() {
         if ((this.defaultServiceRestrictionDays != null) && (this.defaultServiceRestrictionDays > 0)) {
             return defaultServiceRestrictionDays;
@@ -657,10 +986,16 @@ public class Program implements Serializable {
         return this.DEFAULT_SERVICE_RESTRICTION_DAYS;
     }
 
+    /**
+     * Sets the default number of service restriction days for this program.
+     * 
+     * @param defaultServiceRestrictionDays the default service restriction days to set
+     */
     public void setDefaultServiceRestrictionDays(Integer defaultServiceRestrictionDays) {
         this.defaultServiceRestrictionDays = defaultServiceRestrictionDays;
     }
 
+    @Override
     public boolean equals(Object obj) {
         if (null == obj) return false;
         if (!(obj instanceof Program)) return false;
@@ -671,6 +1006,7 @@ public class Program implements Serializable {
         }
     }
 
+    @Override
     public int hashCode() {
         if (Integer.MIN_VALUE == this.hashCode) {
             if (null == this.getId()) return super.hashCode();
@@ -686,152 +1022,310 @@ public class Program implements Serializable {
         return super.toString();
     }
 
+    /**
+     * Gets the description of the facility associated with this program.
+     * 
+     * @return the facility description
+     */
     public String getFacilityDesc() {
         return facilityDesc;
     }
 
+    /**
+     * Sets the description of the facility associated with this program.
+     * 
+     * @param facilityDesc the facility description to set
+     */
     public void setFacilityDesc(String facilityDesc) {
         this.facilityDesc = facilityDesc;
     }
 
+    /**
+     * Gets the total number of rooms used in this program.
+     * 
+     * @return the total used rooms
+     */
     public Integer getTotalUsedRoom() {
         return totalUsedRoom;
     }
 
+    /**
+     * Sets the total number of rooms used in this program.
+     * 
+     * @param totalUsedRoom the total used rooms to set
+     */
     public void setTotalUsedRoom(Integer totalUsedRoom) {
         this.totalUsedRoom = totalUsedRoom;
     }
 
+    /**
+     * Gets the number of intake appointments for this program.
+     * 
+     * @return the number of intakes
+     */
     public Integer getNumOfIntakes() {
         return numOfIntakes;
     }
 
+    /**
+     * Sets the number of intake appointments for this program.
+     * 
+     * @param numOfIntakes the number of intakes to set
+     */
     public void setNumOfIntakes(Integer numOfIntakes) {
         this.numOfIntakes = numOfIntakes;
     }
 
+    /**
+     * Gets the description of the genders served by this program.
+     * 
+     * @return the gender description
+     */
     public String getGenderDesc() {
         return genderDesc;
     }
 
+    /**
+     * Sets the description of the genders served by this program.
+     * 
+     * @param genderDesc the gender description to set
+     */
     public void setGenderDesc(String genderDesc) {
         this.genderDesc = genderDesc;
     }
 
+    /**
+     * Gets the shelter associated with this program.
+     * 
+     * @return the shelter
+     */
     public LookupCodeValue getShelter() {
         return shelter;
     }
 
+    /**
+     * Sets the shelter associated with this program.
+     * 
+     * @param shelter the shelter to set
+     */
     public void setShelter(LookupCodeValue shelter) {
         this.shelter = shelter;
     }
 
+    /**
+     * Checks if encounter time tracking is enabled for this program.
+     * 
+     * @return true if encounter time tracking is enabled, false otherwise
+     */
     public Boolean isEnableEncounterTime() {
         return enableEncounterTime;
     }
 
+    /**
+     * Gets the flag indicating if encounter time tracking is enabled for this program.
+     * 
+     * @return the enableEncounterTime flag
+     */
     public Boolean getEnableEncounterTime() {
         return enableEncounterTime;
     }
 
+    /**
+     * Sets the flag indicating if encounter time tracking is enabled for this program.
+     * 
+     * @param enableEncounterTime the enableEncounterTime flag to set
+     */
     public void setEnableEncounterTime(Boolean enableEncounterTime) {
         this.enableEncounterTime = enableEncounterTime;
     }
-
+    
+    /**
+     * Checks if encounter transportation time tracking is enabled for this program.
+     * 
+     * @return true if encounter transportation time tracking is enabled, false otherwise
+     */
     public Boolean isEnableEncounterTransportationTime() {
         return enableEncounterTransportationTime;
     }
 
+    /**
+     * Gets the flag indicating if encounter transportation time tracking is enabled for this program.
+     * 
+     * @return the enableEncounterTransportationTime flag
+     */
     public Boolean getEnableEncounterTransportationTime() {
         return enableEncounterTransportationTime;
     }
 
+    /**
+     * Sets the flag indicating if encounter transportation time tracking is enabled for this program.
+     * 
+     * @param enableEncounterTransportationTime the enableEncounterTransportationTime flag to set
+     */
     public void setEnableEncounterTransportationTime(Boolean enableEncounterTransportationTime) {
         this.enableEncounterTransportationTime = enableEncounterTransportationTime;
     }
 
+    /**
+     * Gets the comma-separated list of email addresses for notifications related to this program.
+     * 
+     * @return the email notification addresses CSV
+     */
     public String getEmailNotificationAddressesCsv() {
         return emailNotificationAddressesCsv;
     }
 
+    /**
+     * Sets the comma-separated list of email addresses for notifications related to this program.
+     * 
+     * @param emailNotificationAddressesCsv the email notification addresses CSV to set
+     */
     public void setEmailNotificationAddressesCsv(String emailNotificationAddressesCsv) {
         this.emailNotificationAddressesCsv = emailNotificationAddressesCsv;
     }
 
+    /**
+     * Gets the date of the last referral notification for this program.
+     * 
+     * @return the last referral notification date
+     */
     public Date getLastReferralNotification() {
         return lastReferralNotification;
     }
 
+    /**
+     * Sets the date of the last referral notification for this program.
+     * 
+     * @param lastReferralNotification the last referral notification date to set
+     */
     public void setLastReferralNotification(Date lastReferralNotification) {
         this.lastReferralNotification = lastReferralNotification;
     }
 
+    /**
+     * Gets the number of vacancies in this program.
+     * 
+     * @return the number of vacancies
+     */
     public Integer getNoOfVacancy() {
         return noOfVacancy;
     }
 
+    /**
+     * Sets the number of vacancies in this program.
+     * 
+     * @param noOfVacancy the number of vacancies to set
+     */
     public void setNoOfVacancy(Integer noOfVacancy) {
         this.noOfVacancy = noOfVacancy;
     }
 
+    /**
+     * Gets the name of the vacancy in this program.
+     * 
+     * @return the vacancy name
+     */
     public String getVacancyName() {
         return vacancyName;
     }
 
+    /**
+     * Sets the name of the vacancy in this program.
+     * 
+     * @param vacancyName the vacancy name to set
+     */
     public void setVacancyName(String vacancyName) {
         this.vacancyName = vacancyName;
     }
 
+    /**
+     * Gets the date this program was created.
+     * 
+     * @return the date created
+     */
     public String getDateCreated() {
         return dateCreated;
     }
 
+    /**
+     * Sets the date this program was created.
+     * 
+     * @param dateCreated the date created to set
+     */
     public void setDateCreated(String dateCreated) {
         this.dateCreated = dateCreated;
     }
 
+    /**
+     * Gets the number of matches for this program.
+     * 
+     * @return the number of matches
+     */
     public double getMatches() {
         return matches;
     }
 
+    /**
+     * Sets the number of matches for this program.
+     * 
+     * @param matches the number of matches to set
+     */
     public void setMatches(double matches) {
         this.matches = matches;
     }
 
+    /**
+     * Gets the ID of the vacancy in this program.
+     * 
+     * @return the vacancy ID
+     */
     public Integer getVacancyId() {
         return vacancyId;
     }
 
+    /**
+     * Sets the ID of the vacancy in this program.
+     * 
+     * @param vacancyId the vacancy ID to set
+     */
     public void setVacancyId(Integer vacancyId) {
         this.vacancyId = vacancyId;
     }
 
+    /**
+     * Gets the name of the vacancy template used by this program.
+     * 
+     * @return the vacancy template name
+     */
     public String getVacancyTemplateName() {
         return vacancyTemplateName;
     }
 
+    /**
+     * Sets the name of the vacancy template used by this program.
+     * 
+     * @param vacancyTemplateName the vacancy template name to set
+     */
     public void setVacancyTemplateName(String vacancyTemplateName) {
         this.vacancyTemplateName = vacancyTemplateName;
     }
 
-    public static String getIdsAsStringList(List<Program> results) {
-        StringBuilder sb = new StringBuilder();
-
-        for (Program model : results) {
-            sb.append(model.getId().toString());
-            sb.append(',');
-        }
-
-        return (sb.toString());
-    }
-
+    /**
+     * Checks if OCAN (Ontario Common Assessment of Need) is enabled for this program.
+     * 
+     * @return true if OCAN is enabled, false otherwise
+     */
     public boolean isEnableOCAN() {
         return enableOCAN;
     }
 
+    /**
+     * Sets whether OCAN (Ontario Common Assessment of Need) is enabled for this program.
+     * 
+     * @param enableOCAN true if OCAN is enabled, false otherwise
+     */
     public void setEnableOCAN(boolean enableOCAN) {
         this.enableOCAN = enableOCAN;
     }
-
 
 }

--- a/src/main/java/org/oscarehr/PMmodule/model/ProgramAccess.java
+++ b/src/main/java/org/oscarehr/PMmodule/model/ProgramAccess.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 /**
  * Copyright (c) 2005-2012. Centre for Research on Inner City Health, St. Michael's Hospital, Toronto. All Rights Reserved.
  * This software is published under the GPL GNU General Public License.
@@ -21,145 +20,169 @@
  * Toronto, Ontario, Canada
  */
 
-package org.oscarehr.PMmodule.model;
+ package org.oscarehr.PMmodule.model;
 
-import java.io.Serializable;
+ import javax.persistence.Column;
+ import javax.persistence.Entity;
+ import javax.persistence.Id;
+ import javax.persistence.Table;
+ 
+ import java.util.Set;
+ import com.quatro.model.security.Secrole;
 
-import com.quatro.model.security.Secrole;
+import lombok.EqualsAndHashCode;
 
-/**
- * This is the object class that relates to the program_access table. Any customizations belong here.
- */
-public class ProgramAccess implements Serializable {
+import org.oscarehr.common.model.AbstractModel;
+ 
+ /**
+  * This is the object class that relates to the program_access table. Any customizations belong here.
+  */
+ @Entity
+ @Table(name = "program_access")
+ public class ProgramAccess extends AbstractModel<Long> {
 
-    private int hashCode = Integer.MIN_VALUE;// primary key
-    private Long _id;// fields
-    private Long _programId;
-    private String _accessTypeId;
-    private boolean _allRoles;// many to one
-    private AccessType _accessType;// collections
-    private java.util.Set _roles;
+     private int hashCode = Integer.MIN_VALUE;// primary key
 
-    // constructors
-    public ProgramAccess() {
+     @Id
+     @Column(name = "id")
+     private Long _id;
 
-    }
+     @Column(name = "program_id")
+     private Long _programId;
 
-    /**
-     * Constructor for primary key
-     */
-    public ProgramAccess(Long _id) {
-        this.setId(_id);
+     @Column(name = "access_type_id")
+     private String _accessTypeId;
 
-    }
+     @Column(name = "all_roles")
+     private boolean _allRoles;
 
+     @Column(name = "access_type")
+     private AccessType _accessType;
 
-    /**
-     * Return the unique identifier of this class
-     * <p>
-     * generator-class="native"
-     * column="id"
-     */
-    public Long getId() {
-        return _id;
-    }
+     @Column(name = "roles")
+     private Set<Secrole> _roles;
+ 
+     // constructors
+     public ProgramAccess() {
+ 
+     }
+ 
+     /**
+      * Constructor for primary key.
+      * @param _id the ID
+      */
+     public ProgramAccess(Long _id) {
+         this.setId(_id);
+     }  
+ 
+ 
+     @Override
+     public Long getId() {
+         return _id;
+     }
 
-    /**
-     * Set the unique identifier of this class
-     *
-     * @param _id the new ID
-     */
-    public void setId(Long _id) {
-        this._id = _id;
-        this.hashCode = Integer.MIN_VALUE;
-    }
+     /**
+      * Sets the ID.
+      * @param _id the new ID
+      */
+     public void setId(Long _id) {
+         this._id = _id;
+         this.hashCode = Integer.MIN_VALUE;
+     }
+ 
+     /**
+      * Gets the program ID.
+      * @return the program ID
+      */
+     public Long getProgramId() {
+         return _programId;
+     }
 
-    /**
-     * Return the value associated with the column: program_id
-     */
-    public Long getProgramId() {
-        return _programId;
-    }
+     /**
+      * Sets the program ID.
+      * @param _programId the new program ID
+      */
+     public void setProgramId(Long _programId) {
+         this._programId = _programId;
+     }
+ 
+     /**
+      * Gets the access type ID.
+      * @return the access type ID
+      */
+     public String getAccessTypeId() {
+         return _accessTypeId;
+     }
 
-    /**
-     * Set the value related to the column: program_id
-     *
-     * @param _programId the program_id value
-     */
-    public void setProgramId(Long _programId) {
-        this._programId = _programId;
-    }
+     /**
+      * Sets the access type ID.
+      * @param _accessTypeId the new access type ID
+      */
+     public void setAccessTypeId(String _accessTypeId) {
+         this._accessTypeId = _accessTypeId;
+     }
+ 
+     /**
+      * Checks if all roles have this access.
+      * @return true, if all roles have this access
+      */
+     public boolean isAllRoles() {
+         return _allRoles;
+     }
 
-    /**
-     * Return the value associated with the column: access_type_id
-     */
-    public String getAccessTypeId() {
-        return _accessTypeId;
-    }
+     /**
+      * Sets whether all roles have this access.
+      * @param _allRoles the new all roles flag
+      */
+     public void setAllRoles(boolean _allRoles) {
+         this._allRoles = _allRoles;
+     }
+ 
+     /**
+      * Gets the access type.
+      * @return the access type
+      */
+     public AccessType getAccessType() {
+         return this._accessType;
+     }
 
-    /**
-     * Set the value related to the column: access_type_id
-     *
-     * @param _accessTypeId the access_type_id value
-     */
-    public void setAccessTypeId(String _accessTypeId) {
-        this._accessTypeId = _accessTypeId;
-    }
+     /**
+      * Sets the access type.
+      * @param _accessType the new access type
+      */
+     public void setAccessType(AccessType _accessType) {
+         this._accessType = _accessType;
+     }
+ 
+     /**
+      * Gets the roles that have this access.
+      * @return the roles
+      */
+     public java.util.Set<Secrole> getRoles() {
+         return this._roles;
+     }
 
-    /**
-     * Return the value associated with the column: all_roles
-     */
-    public boolean isAllRoles() {
-        return _allRoles;
-    }
+     /**
+      * Sets the roles that have this access.
+      * @param _roles the new roles
+      */
+     public void setRoles(java.util.Set<Secrole> _roles) {
+         this._roles = _roles;
+     }
+ 
+     /**
+      * Adds a role to the set of roles that have this access.
+      * @param role the role to add
+      */
+     public void addToRoles(Secrole role) {
+         if (null == this._roles) {
+             this._roles = new java.util.HashSet<Secrole>();
+         }
+         this._roles.add(role);
+     }
 
-    /**
-     * Set the value related to the column: all_roles
-     *
-     * @param _allRoles the all_roles value
-     */
-    public void setAllRoles(boolean _allRoles) {
-        this._allRoles = _allRoles;
-    }
-
-    /**
-     * column=access_type_id
-     */
-    public AccessType getAccessType() {
-        return this._accessType;
-    }
-
-    /**
-     * Set the value related to the column: access_type_id
-     *
-     * @param _accessType the access_type_id value
-     */
-    public void setAccessType(AccessType _accessType) {
-        this._accessType = _accessType;
-    }
-
-    /**
-     * Return the value associated with the column: roles
-     */
-    public java.util.Set<Secrole> getRoles() {
-        return this._roles;
-    }
-
-    /**
-     * Set the value related to the column: roles
-     *
-     * @param _roles the roles value
-     */
-    public void setRoles(java.util.Set _roles) {
-        this._roles = _roles;
-    }
-
-    public void addToRoles(Object obj) {
-        if (null == this._roles) this._roles = new java.util.HashSet();
-        this._roles.add(obj);
-    }
-
-    public boolean equals(Object obj) {
+     @Override
+     public boolean equals(Object obj) {
         if (null == obj) return false;
         if (!(obj instanceof ProgramAccess)) return false;
         else {
@@ -169,6 +192,7 @@ public class ProgramAccess implements Serializable {
         }
     }
 
+    @Override
     public int hashCode() {
         if (Integer.MIN_VALUE == this.hashCode) {
             if (null == this.getId()) return super.hashCode();
@@ -180,7 +204,9 @@ public class ProgramAccess implements Serializable {
         return this.hashCode;
     }
 
+ 
     public String toString() {
         return super.toString();
     }
+
 }


### PR DESCRIPTION
- Updated the queries in ProgramDaoImpl and ProgramAccessDAOImpl classes to use JPA API.
- Updated the Program and ProgramAccess classes to extend the AbstractModel class, and using javax.persistence library.
- Added/updated jdocs to above classes and the methods.

## Summary by Sourcery

Refactor data access objects to use JPA API, update model classes to extend AbstractModel and use JPA annotations, and enhance documentation with detailed Javadocs.

Enhancements:
- Refactor ProgramDaoImpl and ProgramAccessDAOImpl classes to use JPA API instead of Hibernate templates for database operations.
- Update Program and ProgramAccess classes to extend AbstractModel and utilize JPA annotations for entity mapping.
- Improve code documentation by adding and updating Javadocs for methods and classes in the ProgramDaoImpl, ProgramAccessDAOImpl, Program, and ProgramAccess classes.