### PR TITLE
Aider Script Commits - Fix Positional Param 

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/dao/CriteriaDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/CriteriaDaoImpl.java
@@ -44,8 +44,8 @@ public class CriteriaDaoImpl extends AbstractDaoImpl<Criteria> implements Criter
     }
 
     public List<Criteria> getCriteriaByTemplateId(Integer templateId) {
-        Query q = entityManager.createQuery("select c from Criteria c where c.templateId=?");
-        q.setParameter(0, templateId);
+        Query q = entityManager.createQuery("select c from Criteria c where c.templateId=?1");
+        q.setParameter(1, templateId);
 
         @SuppressWarnings("unchecked")
         List<Criteria> results = q.getResultList();
@@ -55,20 +55,20 @@ public class CriteriaDaoImpl extends AbstractDaoImpl<Criteria> implements Criter
 
     public Criteria getCriteriaByTemplateIdVacancyIdTypeId(Integer templateId, Integer vacancyId, Integer typeId) {
         if (templateId != null && vacancyId != null) {
-            Query q = entityManager.createQuery("select c from Criteria c where c.templateId=? and c.criteriaTypeId=? and c.vacancyId=?");
-            q.setParameter(0, templateId);
+            Query q = entityManager.createQuery("select c from Criteria c where c.templateId=?1 and c.criteriaTypeId=?2 and c.vacancyId=?3");
+            q.setParameter(1, templateId);
+            q.setParameter(2, typeId);
+            q.setParameter(3, vacancyId);
+            return this.getSingleResultOrNull(q);
+        } else if (templateId == null && vacancyId != null) {
+            Query q = entityManager.createQuery("select c from Criteria c where c.templateId IS NULL and c.criteriaTypeId=?1 and c.vacancyId=?2");
             q.setParameter(1, typeId);
             q.setParameter(2, vacancyId);
             return this.getSingleResultOrNull(q);
-        } else if (templateId == null && vacancyId != null) {
-            Query q = entityManager.createQuery("select c from Criteria c where c.templateId IS NULL and c.criteriaTypeId=? and c.vacancyId=?");
-            q.setParameter(0, typeId);
-            q.setParameter(1, vacancyId);
-            return this.getSingleResultOrNull(q);
         } else if (templateId != null && vacancyId == null) {
-            Query q = entityManager.createQuery("select c from Criteria c where c.templateId=? and c.criteriaTypeId=? and c.vacancyId is null");
-            q.setParameter(0, templateId);
-            q.setParameter(1, typeId);
+            Query q = entityManager.createQuery("select c from Criteria c where c.templateId=?1 and c.criteriaTypeId=?2 and c.vacancyId is null");
+            q.setParameter(1, templateId);
+            q.setParameter(2, typeId);
             return this.getSingleResultOrNull(q);
         } else {
             return null;
@@ -78,18 +78,7 @@ public class CriteriaDaoImpl extends AbstractDaoImpl<Criteria> implements Criter
     }
 
     public List<Criteria> getCriteriasByVacancyId(Integer vacancyId) {
-        Query q = entityManager.createQuery("select c from Criteria c where c.vacancyId=?");
-        q.setParameter(0, vacancyId);
-
-        @SuppressWarnings("unchecked")
-        List<Criteria> results = q.getResultList();
-
-        return results;
-    }
-
-    public List<Criteria> getRefinedCriteriasByVacancyId(Integer vacancyId) {
-        Query q = entityManager.createQuery("select c from Criteria c where c.canBeAdhoc!=? and c.vacancyId=?");
-        q.setParameter(0, 0);//canBeAdhoc=0 means don't appear in vacancy.
+        Query q = entityManager.createQuery("select c from Criteria c where c.vacancyId=?1");
         q.setParameter(1, vacancyId);
 
         @SuppressWarnings("unchecked")
@@ -98,10 +87,21 @@ public class CriteriaDaoImpl extends AbstractDaoImpl<Criteria> implements Criter
         return results;
     }
 
+    public List<Criteria> getRefinedCriteriasByVacancyId(Integer vacancyId) {
+        Query q = entityManager.createQuery("select c from Criteria c where c.canBeAdhoc!=?1 and c.vacancyId=?2");
+        q.setParameter(1, 0);//canBeAdhoc=0 means don't appear in vacancy.
+        q.setParameter(2, vacancyId);
+
+        @SuppressWarnings("unchecked")
+        List<Criteria> results = q.getResultList();
+
+        return results;
+    }
+
     public List<Criteria> getRefinedCriteriasByTemplateId(Integer templateId) {
-        Query q = entityManager.createQuery("select c from Criteria c where c.canBeAdhoc!=? and c.templateId=?");
-        q.setParameter(0, 0); //canBeAdhoc=0 means don't appear in vacancy.
-        q.setParameter(1, templateId);
+        Query q = entityManager.createQuery("select c from Criteria c where c.canBeAdhoc!=?1 and c.templateId=?2");
+        q.setParameter(1, 0); //canBeAdhoc=0 means don't appear in vacancy.
+        q.setParameter(2, templateId);
 
         @SuppressWarnings("unchecked")
         List<Criteria> results = q.getResultList();

--- a/src/main/java/org/oscarehr/PMmodule/dao/CriteriaSelectionOptionDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/CriteriaSelectionOptionDaoImpl.java
@@ -44,8 +44,8 @@ public class CriteriaSelectionOptionDaoImpl extends AbstractDaoImpl<CriteriaSele
     }
 
     public List<CriteriaSelectionOption> getCriteriaSelectedOptionsByCriteriaId(Integer criteriaId) {
-        Query query = entityManager.createQuery("select x from CriteriaSelectionOption x where x.criteriaId=?");
-        query.setParameter(0, criteriaId);
+        Query query = entityManager.createQuery("select x from CriteriaSelectionOption x where x.criteriaId=?1");
+        query.setParameter(1, criteriaId);
 
         @SuppressWarnings("unchecked")
         List<CriteriaSelectionOption> results = query.getResultList();

--- a/src/main/java/org/oscarehr/PMmodule/dao/CriteriaTypeDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/CriteriaTypeDaoImpl.java
@@ -53,8 +53,8 @@ public class CriteriaTypeDaoImpl extends AbstractDaoImpl<CriteriaType> implement
     }
 
     public CriteriaType findByName(String fieldName) {
-        Query query = entityManager.createQuery("select x from CriteriaType x where x.fieldName=?");
-        query.setParameter(0, fieldName);
+        Query query = entityManager.createQuery("select x from CriteriaType x where x.fieldName=?1");
+        query.setParameter(1, fieldName);
 
         @SuppressWarnings("unchecked")
         List<CriteriaType> results = query.getResultList();
@@ -66,8 +66,8 @@ public class CriteriaTypeDaoImpl extends AbstractDaoImpl<CriteriaType> implement
     }
 
     public List<CriteriaType> getAllCriteriaTypes() {
-        Query query = entityManager.createQuery("select x from CriteriaType x where x.wlProgramId=? order by x.fieldType DESC");
-        query.setParameter(0, 1);
+        Query query = entityManager.createQuery("select x from CriteriaType x where x.wlProgramId=?1 order by x.fieldType DESC");
+        query.setParameter(1, 1);
 
         @SuppressWarnings("unchecked")
         List<CriteriaType> results = query.getResultList();
@@ -76,8 +76,8 @@ public class CriteriaTypeDaoImpl extends AbstractDaoImpl<CriteriaType> implement
     }
 
     public List<CriteriaType> getAllCriteriaTypesByWlProgramId(Integer wlProgramId) {
-        Query query = entityManager.createQuery("select x from CriteriaType x where x.wlProgramId=? order by x.fieldType DESC");
-        query.setParameter(0, wlProgramId);
+        Query query = entityManager.createQuery("select x from CriteriaType x where x.wlProgramId=?1 order by x.fieldType DESC");
+        query.setParameter(1, wlProgramId);
 
         @SuppressWarnings("unchecked")
         List<CriteriaType> results = query.getResultList();

--- a/src/main/java/org/oscarehr/PMmodule/dao/CriteriaTypeOptionDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/CriteriaTypeOptionDaoImpl.java
@@ -53,8 +53,8 @@ public class CriteriaTypeOptionDaoImpl extends AbstractDaoImpl<CriteriaTypeOptio
     }
 
     public List<CriteriaTypeOption> getCriteriaTypeOptionByTypeId(Integer typeId) {
-        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.criteriaTypeId=?");
-        query.setParameter(0, typeId);
+        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.criteriaTypeId=?1");
+        query.setParameter(1, typeId);
 
         @SuppressWarnings("unchecked")
         List<CriteriaTypeOption> results = query.getResultList();
@@ -63,16 +63,16 @@ public class CriteriaTypeOptionDaoImpl extends AbstractDaoImpl<CriteriaTypeOptio
     }
 
     public CriteriaTypeOption getByValue(String optionValue) {
-        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.optionValue=?");
-        query.setParameter(0, optionValue);
+        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.optionValue=?1");
+        query.setParameter(1, optionValue);
 
         return this.getSingleResultOrNull(query);
     }
 
     public CriteriaTypeOption getByValueAndTypeId(String optionValue, Integer typeId) {
-        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.optionValue=? and x.criteriaTypeId=?");
-        query.setParameter(0, optionValue);
-        query.setParameter(1, typeId);
+        Query query = entityManager.createQuery("select x from CriteriaTypeOption x where x.optionValue=?1 and x.criteriaTypeId=?2");
+        query.setParameter(1, optionValue);
+        query.setParameter(2, typeId);
 
         return this.getSingleResultOrNull(query);
     }

--- a/src/main/java/org/oscarehr/PMmodule/dao/OcanSubmissionLogDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/OcanSubmissionLogDaoImpl.java
@@ -50,44 +50,44 @@ public class OcanSubmissionLogDaoImpl extends AbstractDaoImpl<OcanSubmissionLog>
 
 
     public List<OcanSubmissionLog> findBySubmissionDate(Date submissionDate) {
-        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where date(l.submitDateTime)=?  order by l.submitDateTime DESC");
-        query.setParameter(0, submissionDate);
+        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where date(l.submitDateTime)=?1  order by l.submitDateTime DESC");
+        query.setParameter(1, submissionDate);
         @SuppressWarnings("unchecked")
         List<OcanSubmissionLog> results = query.getResultList();
         return results;
     }
 
     public List<OcanSubmissionLog> findBySubmissionDateType(Date submissionDate, String type) {
-        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where date(l.submitDateTime)=?  and submissionType=? order by l.submitDateTime DESC");
-        query.setParameter(0, submissionDate);
-        query.setParameter(1, type);
-        @SuppressWarnings("unchecked")
-        List<OcanSubmissionLog> results = query.getResultList();
-        return results;
-    }
-
-    public List<OcanSubmissionLog> findBySubmissionDateType(Date submissionStartDate, Date submissionEndDate, String type) {
-        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where submitDateTime>=?  and l.submitDateTime<=? and submissionType=? order by l.submitDateTime DESC");
-        query.setParameter(0, submissionStartDate);
-        query.setParameter(1, submissionEndDate);
+        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where date(l.submitDateTime)=?1  and submissionType=?2 order by l.submitDateTime DESC");
+        query.setParameter(1, submissionDate);
         query.setParameter(2, type);
         @SuppressWarnings("unchecked")
         List<OcanSubmissionLog> results = query.getResultList();
         return results;
     }
 
+    public List<OcanSubmissionLog> findBySubmissionDateType(Date submissionStartDate, Date submissionEndDate, String type) {
+        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where submitDateTime>=?1  and l.submitDateTime<=?2 and submissionType=?3 order by l.submitDateTime DESC");
+        query.setParameter(1, submissionStartDate);
+        query.setParameter(2, submissionEndDate);
+        query.setParameter(3, type);
+        @SuppressWarnings("unchecked")
+        List<OcanSubmissionLog> results = query.getResultList();
+        return results;
+    }
+
     public List<OcanSubmissionLog> findAllByType(String type) {
-        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where l.submissionType=? order by l.submitDateTime DESC");
-        query.setParameter(0, type);
+        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where l.submissionType=?1 order by l.submitDateTime DESC");
+        query.setParameter(1, type);
         @SuppressWarnings("unchecked")
         List<OcanSubmissionLog> results = query.getResultList();
         return results;
     }
 
     public List<OcanSubmissionLog> findFailedSubmissionsByType(String type) {
-        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where l.submissionType=? and l.result=? order by l.submitDateTime DESC");
-        query.setParameter(0, type);
-        query.setParameter(1, "false");
+        Query query = entityManager.createQuery("select l from OcanSubmissionLog l where l.submissionType=?1 and l.result=?2 order by l.submitDateTime DESC");
+        query.setParameter(1, type);
+        query.setParameter(2, "false");
         @SuppressWarnings("unchecked")
         List<OcanSubmissionLog> results = query.getResultList();
         return results;

--- a/src/main/java/org/oscarehr/PMmodule/dao/VacancyClientMatchDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/VacancyClientMatchDaoImpl.java
@@ -45,9 +45,9 @@ public class VacancyClientMatchDaoImpl extends AbstractDaoImpl<VacancyClientMatc
     @Override
     public List<VacancyClientMatch> findByClientIdAndVacancyId(int clientId, int vacancyId) {
         Query q = entityManager
-                .createQuery("select x from VacancyClientMatch x where x.client_id = ? and x.vacancy_id = ?");
-        q.setParameter(0, clientId);
-        q.setParameter(1, vacancyId);
+                .createQuery("select x from VacancyClientMatch x where x.client_id = ?1 and x.vacancy_id = ?2");
+        q.setParameter(1, clientId);
+        q.setParameter(2, vacancyId);
 
         @SuppressWarnings("unchecked")
         List<VacancyClientMatch> results = q.getResultList();
@@ -57,8 +57,8 @@ public class VacancyClientMatchDaoImpl extends AbstractDaoImpl<VacancyClientMatc
 
     @Override
     public List<VacancyClientMatch> findByClientId(int clientId) {
-        Query q = entityManager.createQuery("select x from VacancyClientMatch x where x.client_id = ?");
-        q.setParameter(0, clientId);
+        Query q = entityManager.createQuery("select x from VacancyClientMatch x where x.client_id = ?1");
+        q.setParameter(1, clientId);
 
         @SuppressWarnings("unchecked")
         List<VacancyClientMatch> results = q.getResultList();
@@ -68,8 +68,8 @@ public class VacancyClientMatchDaoImpl extends AbstractDaoImpl<VacancyClientMatc
 
     @Override
     public List<VacancyClientMatch> findBystatus(String status) {
-        Query q = entityManager.createQuery("select x from VacancyClientMatch x where x.status = ?");
-        q.setParameter(0, status);
+        Query q = entityManager.createQuery("select x from VacancyClientMatch x where x.status = ?1");
+        q.setParameter(1, status);
 
         @SuppressWarnings("unchecked")
         List<VacancyClientMatch> results = q.getResultList();

--- a/src/main/java/org/oscarehr/PMmodule/dao/VacancyTemplateDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/VacancyTemplateDaoImpl.java
@@ -60,8 +60,8 @@ public class VacancyTemplateDaoImpl extends AbstractDaoImpl<VacancyTemplate> imp
 
     @Override
     public List<VacancyTemplate> getVacancyTemplateByWlProgramId(Integer wlProgramId) {
-        Query query = entityManager.createQuery("select x from VacancyTemplate x where x.wlProgramId=?");
-        query.setParameter(0, wlProgramId);
+        Query query = entityManager.createQuery("select x from VacancyTemplate x where x.wlProgramId=?1");
+        query.setParameter(1, wlProgramId);
 
         @SuppressWarnings("unchecked")
         List<VacancyTemplate> results = query.getResultList();
@@ -71,9 +71,9 @@ public class VacancyTemplateDaoImpl extends AbstractDaoImpl<VacancyTemplate> imp
 
     @Override
     public List<VacancyTemplate> getActiveVacancyTemplatesByWlProgramId(Integer wlProgramId) {
-        Query query = entityManager.createQuery("select x from VacancyTemplate x where x.wlProgramId=? and x.active=?");
-        query.setParameter(0, wlProgramId);
-        query.setParameter(1, true);
+        Query query = entityManager.createQuery("select x from VacancyTemplate x where x.wlProgramId=?1 and x.active=?2");
+        query.setParameter(1, wlProgramId);
+        query.setParameter(2, true);
 
         @SuppressWarnings("unchecked")
         List<VacancyTemplate> results = query.getResultList();

--- a/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MessageDao.java
+++ b/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7MessageDao.java
@@ -45,13 +45,13 @@ public class Hl7MessageDao extends AbstractDaoImpl<Hl7Message> {
         String sql =
                 "FROM Hl7Message m, " + PatientLabRouting.class.getSimpleName() + " patientLabRouting " +
                         "WHERE patientLabRouting.labNo = m.id " +
-                        "AND patientLabRouting.labType = :labType " +
-                        "AND patientLabRouting.demographicNo = :demographicNo " +
+                        "AND patientLabRouting.labType = ?1 " +
+                        "AND patientLabRouting.demographicNo = ?2 " +
                         "GROUP BY m.id";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter("demographicNo", demographicNo);
-        query.setParameter("labType", labType);
+        query.setParameter(1, labType);
+        query.setParameter(2, demographicNo);
         return query.getResultList();
     }
 }

--- a/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7ObrDao.java
+++ b/src/main/java/org/oscarehr/billing/CA/BC/dao/Hl7ObrDao.java
@@ -49,10 +49,10 @@ public class Hl7ObrDao extends AbstractDaoImpl<Hl7Obr> {
     public List<Object[]> findLabResultsByPid(Integer pid) {
         String sql = "FROM Hl7Obr hl7_obr, Hl7Obx hl7_obx " +
                 "WHERE hl7_obr.id = hl7_obx.obrId " +
-                "AND hl7_obr.pidId = :pid " +
+                "AND hl7_obr.pidId = ?1 " +
                 "ORDER BY hl7_obr.diagnosticServiceSectId";
         Query query = entityManager.createQuery(sql);
-        query.setParameter("pid", pid);
+        query.setParameter(1, pid);
         return query.getResultList();
     }
 
@@ -60,9 +60,9 @@ public class Hl7ObrDao extends AbstractDaoImpl<Hl7Obr> {
         String sql = "SELECT MIN(obr.resultStatus) FROM Hl7Pid pid, Hl7Obr obr, Hl7Obx obx " +
                 "WHERE obr.pidId = pid.id " +
                 "AND obx.obrId = obr.id " +
-                "AND pid.messageId = :messageId";
+                "AND pid.messageId = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter("messageId", messageId);
+        query.setParameter(1, messageId);
         return query.getResultList();
     }
 
@@ -70,9 +70,9 @@ public class Hl7ObrDao extends AbstractDaoImpl<Hl7Obr> {
         String sql = "FROM Hl7Pid pid, Hl7Obr obr, Hl7Obx obx " +
                 "WHERE obr.pidId = pid.id " +
                 "AND obx.obrId = obr.id " +
-                "AND pid.messageId = :messageId";
+                "AND pid.messageId = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter("messageId", messageId);
+        query.setParameter(1, messageId);
         return query.getResultList();
     }
 

--- a/src/main/java/org/oscarehr/eyeform/dao/EyeformConsultationReportDao.java
+++ b/src/main/java/org/oscarehr/eyeform/dao/EyeformConsultationReportDao.java
@@ -70,7 +70,7 @@ public class EyeformConsultationReportDao extends AbstractDaoImpl<EyeformConsult
                 sql += " AND ";
                 pos++;
             }
-            sql += "x.status = ?";
+            sql += "x.status = ?" + pos;
             params.put(pos, queryBean.getStatus());
         }
         if (queryBean.getProviderNo() != null) {
@@ -81,7 +81,7 @@ public class EyeformConsultationReportDao extends AbstractDaoImpl<EyeformConsult
                 sql += " AND ";
                 pos++;
             }
-            sql += "x.providerNo = ?";
+            sql += "x.providerNo = ?" + pos;
             params.put(pos, queryBean.getProviderNo());
         }
         if (queryBean.getDemographicNo() > 0) {
@@ -92,7 +92,7 @@ public class EyeformConsultationReportDao extends AbstractDaoImpl<EyeformConsult
                 sql += " AND ";
                 pos++;
             }
-            sql += "x.demographicNo = ?";
+            sql += "x.demographicNo = ?" + pos;
             params.put(pos, queryBean.getDemographicNo());
         }
 
@@ -104,7 +104,7 @@ public class EyeformConsultationReportDao extends AbstractDaoImpl<EyeformConsult
                 sql += " AND ";
                 pos++;
             }
-            sql += "x.date >=?";
+            sql += "x.date >=?" + pos;
             params.put(pos, startDate);
         }
 
@@ -116,7 +116,7 @@ public class EyeformConsultationReportDao extends AbstractDaoImpl<EyeformConsult
                 sql += " AND ";
                 pos++;
             }
-            sql += "x.date <=?";
+            sql += "x.date <=?" + pos;
             params.put(pos, endDate);
         }
 

--- a/src/main/java/org/oscarehr/eyeform/dao/EyeformOcularProcedureDao.java
+++ b/src/main/java/org/oscarehr/eyeform/dao/EyeformOcularProcedureDao.java
@@ -57,11 +57,11 @@ public class EyeformOcularProcedureDao extends AbstractDaoImpl<EyeformOcularProc
     }
 
     public List<EyeformOcularProcedure> getByDateRange(int demographicNo, Date startDate, Date endDate) {
-        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo=? and x.date >= ? and x.date <=?";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo=?1 and x.date >= ?2 and x.date <=?3";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicNo);
-        query.setParameter(1, startDate);
-        query.setParameter(2, endDate);
+        query.setParameter(1, demographicNo);
+        query.setParameter(2, startDate);
+        query.setParameter(3, endDate);
 
         @SuppressWarnings("unchecked")
         List<EyeformOcularProcedure> results = query.getResultList();
@@ -97,10 +97,10 @@ public class EyeformOcularProcedureDao extends AbstractDaoImpl<EyeformOcularProc
     }
 
     public List<EyeformOcularProcedure> getAllPreviousAndCurrent(int demographicNo, int appointmentNo) {
-        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo = ? and x.appointmentNo<=?";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo = ?1 and x.appointmentNo<=?2";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicNo);
-        query.setParameter(1, appointmentNo);
+        query.setParameter(1, demographicNo);
+        query.setParameter(2, appointmentNo);
 
         @SuppressWarnings("unchecked")
         List<EyeformOcularProcedure> results = query.getResultList();

--- a/src/main/java/org/oscarehr/eyeform/dao/EyeformSpecsHistoryDao.java
+++ b/src/main/java/org/oscarehr/eyeform/dao/EyeformSpecsHistoryDao.java
@@ -54,11 +54,11 @@ public class EyeformSpecsHistoryDao extends AbstractDaoImpl<EyeformSpecsHistory>
     }
 
     public List<EyeformSpecsHistory> getByDateRange(int demographicNo, Date startDate, Date endDate) {
-        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo=? and x.date >= ? and x.date <=?";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo=?1 and x.date >= ?2 and x.date <=?3";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicNo);
-        query.setParameter(1, startDate);
-        query.setParameter(2, endDate);
+        query.setParameter(1, demographicNo);
+        query.setParameter(2, startDate);
+        query.setParameter(3, endDate);
 
         @SuppressWarnings("unchecked")
         List<EyeformSpecsHistory> results = query.getResultList();
@@ -94,10 +94,10 @@ public class EyeformSpecsHistoryDao extends AbstractDaoImpl<EyeformSpecsHistory>
     }
 
     public List<EyeformSpecsHistory> getAllPreviousAndCurrent(int demographicNo, int appointmentNo) {
-        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo = ? and x.appointmentNo<=? order by x.date DESC";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.demographicNo = ?1 and x.appointmentNo<=?2 order by x.date DESC";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicNo);
-        query.setParameter(1, appointmentNo);
+        query.setParameter(1, demographicNo);
+        query.setParameter(2, appointmentNo);
 
         @SuppressWarnings("unchecked")
         List<EyeformSpecsHistory> results = query.getResultList();

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
@@ -29,7 +29,7 @@ public class HRMCategoryDao extends AbstractDaoImpl<HRMCategory> {
     public List<HRMCategory> findById(int id) {
         String sql = "select x from " + this.modelClass.getName() + " x where x.id=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         @SuppressWarnings("unchecked")
         List<HRMCategory> documents = query.getResultList();
         return documents;

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMCategoryDao.java
@@ -27,7 +27,7 @@ public class HRMCategoryDao extends AbstractDaoImpl<HRMCategory> {
     }
 
     public List<HRMCategory> findById(int id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.id=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.id=?1";
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, id);
         @SuppressWarnings("unchecked")

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentCommentDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentCommentDao.java
@@ -26,9 +26,9 @@ public class HRMDocumentCommentDao extends AbstractDaoImpl<HRMDocumentComment> {
 
     @SuppressWarnings("unchecked")
     public List<HRMDocumentComment> getCommentsForDocument(Integer documentId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=? and x.deleted=0 order by commentTime desc";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1 and x.deleted=0 order by commentTime desc";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, documentId);
+        query.setParameter(1, documentId);
         return query.getResultList();
     }
 

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentDao.java
@@ -29,9 +29,9 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
     }
 
     public List<HRMDocument> findById(int id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.id=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.id=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         @SuppressWarnings("unchecked")
         List<HRMDocument> documents = query.getResultList();
         return documents;
@@ -59,18 +59,18 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
 
 
     public List<Integer> findByHash(String hash) {
-        String sql = "select distinct id from " + this.modelClass.getName() + " x where x.reportHash=?";
+        String sql = "select distinct id from " + this.modelClass.getName() + " x where x.reportHash=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hash);
+        query.setParameter(1, hash);
         @SuppressWarnings("unchecked")
         List<Integer> matches = query.getResultList();
         return matches;
     }
 
     public List<HRMDocument> findByNoTransactionInfoHash(String hash) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.reportLessTransactionInfoHash=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.reportLessTransactionInfoHash=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hash);
+        query.setParameter(1, hash);
         @SuppressWarnings("unchecked")
         List<HRMDocument> matches = query.getResultList();
         return matches;
@@ -78,9 +78,9 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
 
     @SuppressWarnings("unchecked")
     public List<Integer> findAllWithSameNoDemographicInfoHash(String hash) {
-        String sql = "select distinct parentReport from " + this.modelClass.getName() + " x where x.reportLessDemographicInfoHash=?";
+        String sql = "select distinct parentReport from " + this.modelClass.getName() + " x where x.reportLessDemographicInfoHash=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hash);
+        query.setParameter(1, hash);
         List<Integer> matches = query.getResultList();
 
         if (matches != null && matches.size() == 1 && matches.get(0) == null) {
@@ -129,21 +129,21 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
     }
 
     public List<HRMDocument> getAllChildrenOf(Integer docId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.parentReport=? and x.id != ? order by id asc";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.parentReport=?1 and x.id != ?2 order by id asc";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, docId);
         query.setParameter(1, docId);
+        query.setParameter(2, docId);
         @SuppressWarnings("unchecked")
         List<HRMDocument> documents = query.getResultList();
         return documents;
     }
 
     public List<HRMDocument> findByKey(String sourceFacility, String sourceFacilityReportNo, String deliverToId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.sourceFacility=? AND x.sourceFacilityReportNo = ? AND x.recipientId = ?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.sourceFacility=?1 AND x.sourceFacilityReportNo = ?2 AND x.recipientId = ?3";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, sourceFacility);
-        query.setParameter(1, sourceFacilityReportNo);
-        query.setParameter(2, deliverToId);
+        query.setParameter(1, sourceFacility);
+        query.setParameter(2, sourceFacilityReportNo);
+        query.setParameter(3, deliverToId);
 
         @SuppressWarnings("unchecked")
         List<HRMDocument> documents = query.getResultList();

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentDao.java
@@ -84,9 +84,9 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
         List<Integer> matches = query.getResultList();
 
         if (matches != null && matches.size() == 1 && matches.get(0) == null) {
-            sql = "select distinct id from " + this.modelClass.getName() + " x where x.reportLessDemographicInfoHash=?";
+            sql = "select distinct id from " + this.modelClass.getName() + " x where x.reportLessDemographicInfoHash=?1";
             query = entityManager.createQuery(sql);
-            query.setParameter(0, hash);
+            query.setParameter(1, hash);
             matches = query.getResultList();
         }
         return matches;
@@ -102,23 +102,23 @@ public class HRMDocumentDao extends AbstractDaoImpl<HRMDocument> {
             Query query = null;
             if (firstDocument.getParentReport() != null && !firstDocument.getParentReport().equals(docId)) {
                 // This is a child report; get the parent and all siblings of this report (which includes itself)
-                sql = "select x from " + this.modelClass.getName() + " x where x.id = ? order by x.id asc";
+                sql = "select x from " + this.modelClass.getName() + " x where x.id = ?1 order by x.id asc";
                 query = entityManager.createQuery(sql);
-                query.setParameter(0, firstDocument.getParentReport());
+                query.setParameter(1, firstDocument.getParentReport());
                 documentsWithRelationship.addAll(query.getResultList());
 
-                sql = "select x from " + this.modelClass.getName() + " x where x.parentReport = ? order by x.id asc";
+                sql = "select x from " + this.modelClass.getName() + " x where x.parentReport = ?1 order by x.id asc";
                 query = entityManager.createQuery(sql);
-                query.setParameter(0, firstDocument.getParentReport());
+                query.setParameter(1, firstDocument.getParentReport());
                 documentsWithRelationship.addAll(query.getResultList());
 
 
             } else {
                 // This is a parent report; get all the children of this report as well as itself
-                sql = "select x from " + this.modelClass.getName() + " x where x.parentReport = ? or x.id = ?  order by x.id asc";
+                sql = "select x from " + this.modelClass.getName() + " x where x.parentReport = ?1 or x.id = ?2  order by x.id asc";
                 query = entityManager.createQuery(sql);
-                query.setParameter(0, firstDocument.getId());
                 query.setParameter(1, firstDocument.getId());
+                query.setParameter(2, firstDocument.getId());
                 documentsWithRelationship = query.getResultList();
             }
 

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentSubClassDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentSubClassDao.java
@@ -26,27 +26,27 @@ public class HRMDocumentSubClassDao extends AbstractDaoImpl<HRMDocumentSubClass>
     }
 
     public List<HRMDocumentSubClass> getSubClassesByDocumentId(Integer id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         @SuppressWarnings("unchecked")
         List<HRMDocumentSubClass> subClasses = query.getResultList();
         return subClasses;
     }
 
     public List<HRMDocumentSubClass> getActiveSubClassesByDocumentId(Integer id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=? and x.isActive=1";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1 and x.isActive=1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         @SuppressWarnings("unchecked")
         List<HRMDocumentSubClass> subClasses = query.getResultList();
         return subClasses;
     }
 
     public boolean setAllSubClassesForDocumentAsInactive(Integer id) {
-        String sql = "update " + this.modelClass.getName() + " x set isActive=false where x.hrmDocumentId=?";
+        String sql = "update " + this.modelClass.getName() + " x set isActive=false where x.hrmDocumentId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         return query.executeUpdate() > 0;
     }
 }

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
@@ -32,10 +32,10 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
 
 
     public List<HRMDocumentToDemographic> findByDemographicNo(String demographicNo) {
-        String sql = "select x from " + this.modelClass.getName() + " x, HRMDocument h where x.hrmDocumentId = h.id and  x.demographicNo=? order by h.reportDate DESC";
+        String sql = "select x from " + this.modelClass.getName() + " x, HRMDocument h where x.hrmDocumentId = h.id and  x.demographicNo=?1 order by h.reportDate DESC";
         Query query = entityManager.createQuery(sql);
         Integer demographicNoInteger = Integer.parseInt(demographicNo);
-        query.setParameter(0, demographicNoInteger);
+        query.setParameter(1, demographicNoInteger);
         @SuppressWarnings("unchecked")
         List<HRMDocumentToDemographic> documentToDemographics = query.getResultList();
         return documentToDemographics;
@@ -46,9 +46,9 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
      */
     @Deprecated
     public List<HRMDocumentToDemographic> findByHrmDocumentId(String hrmDocumentId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hrmDocumentId);
+        query.setParameter(1, hrmDocumentId);
         @SuppressWarnings("unchecked")
         List<HRMDocumentToDemographic> documentToDemographics = query.getResultList();
         return documentToDemographics;

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToDemographicDao.java
@@ -85,12 +85,12 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
                         + "FROM " + this.modelClass.getName() + " hdtd "
                         + "WHERE hdtd.hrmDocumentId IN (SELECT cd.documentNo "
                         + "FROM " + ConsultDocs.class.getName() + " cd "
-                        + "WHERE cd.requestId = ? AND cd.docType = 'H' AND cd.deleted IS NULL)";
+                        + "WHERE cd.requestId = ?1 AND cd.docType = 'H' AND cd.deleted IS NULL)";
 
                 //Creates the query using the SQL
                 Query query = entityManager.createQuery(sql);
                 //Sets the query parameters
-                query.setParameter(0, parsedConsultationId);
+                query.setParameter(1, parsedConsultationId);
                 //Gets the query results and converts them to ConsultDocs
                 attachedHRMDocumentToDemographics = query.getResultList();
             } catch (NumberFormatException nfe) {
@@ -129,12 +129,12 @@ public class HRMDocumentToDemographicDao extends AbstractDaoImpl<HRMDocumentToDe
                         + "FROM " + this.modelClass.getName() + " hdtd "
                         + "WHERE hdtd.hrmDocumentId IN (SELECT cd.documentNo "
                         + "FROM " + EFormDocs.class.getName() + " cd "
-                        + "WHERE cd.fdid = ? AND cd.docType = 'H' AND cd.deleted IS NULL)";
+                        + "WHERE cd.fdid = ?1 AND cd.docType = 'H' AND cd.deleted IS NULL)";
 
                 //Creates the query using the SQL
                 Query query = entityManager.createQuery(sql);
                 //Sets the query parameters
-                query.setParameter(0, parsedFdid);
+                query.setParameter(1, parsedFdid);
                 //Gets the query results and converts them to EFormDocs
                 attachedHRMDocumentToDemographics = query.getResultList();
             } catch (NumberFormatException nfe) {

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToProviderDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMDocumentToProviderDao.java
@@ -40,9 +40,9 @@ public class HRMDocumentToProviderDao extends AbstractDaoImpl<HRMDocumentToProvi
     }
 
     public List<HRMDocumentToProvider> findByProviderNo(String providerNo, Integer page, Integer pageSize) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.providerNo=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.providerNo=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, providerNo);
+        query.setParameter(1, providerNo);
         query.setMaxResults(pageSize);
         query.setFirstResult(page * pageSize);
         @SuppressWarnings("unchecked")
@@ -120,28 +120,28 @@ public class HRMDocumentToProviderDao extends AbstractDaoImpl<HRMDocumentToProvi
 
 
     public List<HRMDocumentToProvider> findByHrmDocumentId(Integer hrmDocumentId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hrmDocumentId);
+        query.setParameter(1, hrmDocumentId);
         @SuppressWarnings("unchecked")
         List<HRMDocumentToProvider> documentToProviders = query.getResultList();
         return documentToProviders;
     }
 
     public List<HRMDocumentToProvider> findByHrmDocumentIdNoSystemUser(Integer hrmDocumentId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=? and x.providerNo != '-1'";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1 and x.providerNo != '-1'";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hrmDocumentId);
+        query.setParameter(1, hrmDocumentId);
         @SuppressWarnings("unchecked")
         List<HRMDocumentToProvider> documentToProviders = query.getResultList();
         return documentToProviders;
     }
 
     public HRMDocumentToProvider findByHrmDocumentIdAndProviderNo(Integer hrmDocumentId, String providerNo) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=? and x.providerNo=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1 and x.providerNo=?2";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hrmDocumentId);
-        query.setParameter(1, providerNo);
+        query.setParameter(1, hrmDocumentId);
+        query.setParameter(2, providerNo);
         try {
             List<HRMDocumentToProvider> results = query.getResultList();
             return results.get(results.size() - 1);
@@ -161,18 +161,18 @@ public class HRMDocumentToProviderDao extends AbstractDaoImpl<HRMDocumentToProvi
     }
 
     public List<HRMDocumentToProvider> findSignedByHrmDocumentId(Integer hrmDocumentId) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=? and x.signedOff=1";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.hrmDocumentId=?1 and x.signedOff=1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, hrmDocumentId);
+        query.setParameter(1, hrmDocumentId);
         @SuppressWarnings("unchecked")
         List<HRMDocumentToProvider> documentToProviders = query.getResultList();
         return documentToProviders;
     }
 
     public Integer getCountByProviderNo(String providerNo) {
-        String sql = "select count(*) from " + this.modelClass.getName() + " x where x.providerNo=? and x.signedOff=0";
+        String sql = "select count(*) from " + this.modelClass.getName() + " x where x.providerNo=?1 and x.signedOff=0";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, providerNo);
+        query.setParameter(1, providerNo);
         @SuppressWarnings("unchecked")
         Long result = (Long) query.getSingleResult();
         return result.intValue();

--- a/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMProviderConfidentialityStatementDao.java
+++ b/src/main/java/org/oscarehr/hospitalReportManager/dao/HRMProviderConfidentialityStatementDao.java
@@ -24,9 +24,9 @@ public class HRMProviderConfidentialityStatementDao extends AbstractDaoImpl<HRMP
     }
 
     public String getConfidentialityStatementForProvider(String providerNo) {
-        String sql = "select x.statement from " + this.modelClass.getName() + " x where x.providerNo=?";
+        String sql = "select x.statement from " + this.modelClass.getName() + " x where x.providerNo=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, providerNo);
+        query.setParameter(1, providerNo);
         try {
             return (String) query.getSingleResult();
         } catch (Exception e) {
@@ -36,9 +36,9 @@ public class HRMProviderConfidentialityStatementDao extends AbstractDaoImpl<HRMP
     }
 
     public HRMProviderConfidentialityStatement findByProvider(String providerNo) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.providerNo=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.providerNo=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, providerNo);
+        query.setParameter(1, providerNo);
         return this.getSingleResultOrNull(query);
     }
 

--- a/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
@@ -29,7 +29,7 @@ public class OLISProviderPreferencesDao extends AbstractDaoImpl<OLISProviderPref
         try {
             String sql = "select x from " + this.modelClass.getName() + " x where x.providerId=?";
             Query query = entityManager.createQuery(sql);
-            query.setParameter(0, id);
+            query.setParameter(1, id);
             return (OLISProviderPreferences) query.getSingleResult();
         } catch (javax.persistence.NoResultException nre) {
             return null;

--- a/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISProviderPreferencesDao.java
@@ -27,7 +27,7 @@ public class OLISProviderPreferencesDao extends AbstractDaoImpl<OLISProviderPref
 
     public OLISProviderPreferences findById(String id) {
         try {
-            String sql = "select x from " + this.modelClass.getName() + " x where x.providerId=?";
+            String sql = "select x from " + this.modelClass.getName() + " x where x.providerId=?1";
             Query query = entityManager.createQuery(sql);
             query.setParameter(1, id);
             return (OLISProviderPreferences) query.getSingleResult();

--- a/src/main/java/org/oscarehr/olis/dao/OLISRequestNomenclatureDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISRequestNomenclatureDao.java
@@ -26,9 +26,9 @@ public class OLISRequestNomenclatureDao extends AbstractDaoImpl<OLISRequestNomen
     }
 
     public OLISRequestNomenclature findByNameId(String id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.nameId=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.nameId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         return this.getSingleResultOrNull(query);
     }
 

--- a/src/main/java/org/oscarehr/olis/dao/OLISResultNomenclatureDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISResultNomenclatureDao.java
@@ -26,9 +26,9 @@ public class OLISResultNomenclatureDao extends AbstractDaoImpl<OLISResultNomencl
     }
 
     public OLISResultNomenclature findByNameId(String id) {
-        String sql = "select x from " + this.modelClass.getName() + " x where x.nameId=?";
+        String sql = "select x from " + this.modelClass.getName() + " x where x.nameId=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
         return this.getSingleResultOrNull(query);
     }
 

--- a/src/main/java/org/oscarehr/olis/dao/OLISSystemPreferencesDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISSystemPreferencesDao.java
@@ -25,8 +25,8 @@ public class OLISSystemPreferencesDao extends AbstractDaoImpl<OLISSystemPreferen
 
     public OLISSystemPreferences getPreferences() {
         try {
-            String sql = "select x from " + this.modelClass.getName() + " x where x.id = ?1";
-            Query query = entityManager.createQuery(sql).setParameter(1, someParameter);
+            String sql = "select x from " + this.modelClass.getName() + " x";
+            Query query = entityManager.createQuery(sql);
             return (OLISSystemPreferences) query.getSingleResult();
         } catch (javax.persistence.NoResultException nre) {
             return new OLISSystemPreferences();

--- a/src/main/java/org/oscarehr/olis/dao/OLISSystemPreferencesDao.java
+++ b/src/main/java/org/oscarehr/olis/dao/OLISSystemPreferencesDao.java
@@ -25,8 +25,8 @@ public class OLISSystemPreferencesDao extends AbstractDaoImpl<OLISSystemPreferen
 
     public OLISSystemPreferences getPreferences() {
         try {
-            String sql = "select x from " + this.modelClass.getName() + " x";
-            Query query = entityManager.createQuery(sql);
+            String sql = "select x from " + this.modelClass.getName() + " x where x.id = ?1";
+            Query query = entityManager.createQuery(sql).setParameter(1, someParameter);
             return (OLISSystemPreferences) query.getSingleResult();
         } catch (javax.persistence.NoResultException nre) {
             return new OLISSystemPreferences();

--- a/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
+++ b/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
@@ -46,7 +46,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     private static Logger logger = MiscUtils.getLogger();
 
     public List<PHRAction> getQueuedActions(String providerNo) {
-        String sql = "from PHRAction a where (a.senderOscar = ? OR (a.receiverOscar = ? AND phr_classification = ?)) and a.status = " + PHRAction.STATUS_SEND_PENDING;
+        String sql = "from PHRAction a where (a.senderOscar = ?1 OR (a.receiverOscar = ?2 AND phr_classification = ?3)) and a.status = " + PHRAction.STATUS_SEND_PENDING;
         String[] f = new String[3];
         f[0] = providerNo;
         f[1] = providerNo;
@@ -56,7 +56,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionByPhrIndex(String phrIndex) {
-        String sql = "from PHRAction a where a.phrIndex=?";
+        String sql = "from PHRAction a where a.phrIndex=?1";
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, new String(phrIndex));
         if (list == null || list.isEmpty()) {
             return null;
@@ -71,7 +71,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public PHRAction getActionById(String id) {
-        String sql = "from PHRAction a where a.id = ? ";
+        String sql = "from PHRAction a where a.id = ?1 ";
 
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, new Integer(id));
 
@@ -84,7 +84,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
 
     // actionType = -1 for all actions
     public List<PHRAction> getPendingActionsByProvider(String classification, int actionType, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.senderOscar = ? AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
+        String sql = "FROM PHRAction a WHERE a.phrClassification = ?1 AND a.senderOscar = ?2 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
         if (actionType != -1) {
             sql = sql + " AND a.actionType = " + actionType;
         }
@@ -101,7 +101,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getPendingActionsByProvider(int actionType, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.senderOscar = ? AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
+        String sql = "FROM PHRAction a WHERE a.senderOscar = ?1 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
         if (actionType != -1) {
             sql = sql + " AND a.actionType = " + actionType;
         }
@@ -118,7 +118,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(int status, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.status = " + status;
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.status = " + status;
         String[] f = new String[1];
         f[0] = providerNo;
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, f);
@@ -130,7 +130,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(int status, String providerNo, String classification) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.phrClassification = ? AND a.status = " + status;
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.phrClassification = ?2 AND a.status = " + status;
         String[] f = new String[2];
         f[0] = providerNo;
         f[1] = classification;
@@ -143,7 +143,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(List<Integer> statuses, String providerNo, String classification) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.phrClassification = ?";
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.phrClassification = ?2";
         if (statuses != null && !statuses.isEmpty()) {
             sql += " AND (";
             for (int i = 0; i < statuses.size(); i++) {
@@ -183,7 +183,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
 
     public void updatePhrIndexes(String classification, String oscarId, String providerNo, String newPhrIndex) {
         HibernateTemplate ht = getHibernateTemplate();
-        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.oscarId = ? AND a.senderOscar = ? AND a.status = " + PHRAction.STATUS_SEND_PENDING;
+        String sql = "FROM PHRAction a WHERE a.phrClassification = ?1 AND a.oscarId = ?2 AND a.senderOscar = ?3 AND a.status = " + PHRAction.STATUS_SEND_PENDING;
         String[] f = new String[3];
         f[0] = classification;
         f[1] = oscarId;

--- a/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
+++ b/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
@@ -46,7 +46,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     private static Logger logger = MiscUtils.getLogger();
 
     public List<PHRAction> getQueuedActions(String providerNo) {
-        String sql = "from PHRAction a where (a.senderOscar = ?1 OR (a.receiverOscar = ?2 AND phr_classification = ?3)) and a.status = " + PHRAction.STATUS_SEND_PENDING;
+        String sql = "from PHRAction a where (a.senderOscar = ? OR (a.receiverOscar = ? AND phr_classification = ?)) and a.status = " + PHRAction.STATUS_SEND_PENDING;
         String[] f = new String[3];
         f[0] = providerNo;
         f[1] = providerNo;
@@ -71,7 +71,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public PHRAction getActionById(String id) {
-        String sql = "from PHRAction a where a.id = ?1 ";
+        String sql = "from PHRAction a where a.id = ? ";
 
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, new Integer(id));
 
@@ -84,7 +84,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
 
     // actionType = -1 for all actions
     public List<PHRAction> getPendingActionsByProvider(String classification, int actionType, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.phrClassification = ?1 AND a.senderOscar = ?2 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
+        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.senderOscar = ?2 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
         if (actionType != -1) {
             sql = sql + " AND a.actionType = " + actionType;
         }
@@ -101,7 +101,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getPendingActionsByProvider(int actionType, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.senderOscar = ?1 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
+        String sql = "FROM PHRAction a WHERE a.senderOscar = ? AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
         if (actionType != -1) {
             sql = sql + " AND a.actionType = " + actionType;
         }
@@ -118,7 +118,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(int status, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.status = " + status;
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.status = " + status;
         String[] f = new String[1];
         f[0] = providerNo;
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, f);
@@ -130,7 +130,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(int status, String providerNo, String classification) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.phrClassification = ?2 AND a.status = " + status;
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.phrClassification = ? AND a.status = " + status;
         String[] f = new String[2];
         f[0] = providerNo;
         f[1] = classification;
@@ -143,7 +143,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionsByStatus(List<Integer> statuses, String providerNo, String classification) {
-        String sql = "FROM PHRAction a WHERE a.receiverOscar = ?1 AND a.phrClassification = ?2";
+        String sql = "FROM PHRAction a WHERE a.receiverOscar = ? AND a.phrClassification = ?";
         if (statuses != null && !statuses.isEmpty()) {
             sql += " AND (";
             for (int i = 0; i < statuses.size(); i++) {
@@ -183,7 +183,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
 
     public void updatePhrIndexes(String classification, String oscarId, String providerNo, String newPhrIndex) {
         HibernateTemplate ht = getHibernateTemplate();
-        String sql = "FROM PHRAction a WHERE a.phrClassification = ?1 AND a.oscarId = ?2 AND a.senderOscar = ?3 AND a.status = " + PHRAction.STATUS_SEND_PENDING;
+        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.oscarId = ? AND a.senderOscar = ? AND a.status = " + PHRAction.STATUS_SEND_PENDING;
         String[] f = new String[3];
         f[0] = classification;
         f[1] = oscarId;

--- a/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
+++ b/src/main/java/org/oscarehr/phr/dao/PHRActionDAO.java
@@ -56,7 +56,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
     }
 
     public List<PHRAction> getActionByPhrIndex(String phrIndex) {
-        String sql = "from PHRAction a where a.phrIndex=?1";
+        String sql = "from PHRAction a where a.phrIndex=?";
         List<PHRAction> list = (List<PHRAction>) getHibernateTemplate().find(sql, new String(phrIndex));
         if (list == null || list.isEmpty()) {
             return null;
@@ -84,7 +84,7 @@ public class PHRActionDAO extends HibernateDaoSupport {
 
     // actionType = -1 for all actions
     public List<PHRAction> getPendingActionsByProvider(String classification, int actionType, String providerNo) {
-        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.senderOscar = ?2 AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
+        String sql = "FROM PHRAction a WHERE a.phrClassification = ? AND a.senderOscar = ? AND a.status != " + PHRAction.STATUS_SENT + " AND a.status != " + PHRAction.STATUS_NOT_SENT_DELETED;
         if (actionType != -1) {
             sql = sql + " AND a.actionType = " + actionType;
         }

--- a/src/main/java/org/oscarehr/sharingcenter/dao/AffinityDomainDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/AffinityDomainDao.java
@@ -46,9 +46,9 @@ public class AffinityDomainDao extends AbstractDaoImpl<AffinityDomainDataObject>
      * @return AffinityDomain
      */
     public AffinityDomainDataObject getAffinityDomain(int id) {
-        String sql = "FROM AffinityDomainDataObject a where a.id = ?";
+        String sql = "FROM AffinityDomainDataObject a where a.id = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
 
         AffinityDomainDataObject retVal = getSingleResultOrNull(query);
         return retVal;

--- a/src/main/java/org/oscarehr/sharingcenter/dao/ClinicInfoDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/ClinicInfoDao.java
@@ -46,7 +46,6 @@ public class ClinicInfoDao extends AbstractDaoImpl<ClinicInfoDataObject> {
      */
     public ClinicInfoDataObject getClinic() {
         Query query = entityManager.createQuery("FROM ClinicInfoDataObject c");
-        query.setMaxResults(1);
 
         query.setMaxResults(1);
         ClinicInfoDataObject retVal = getSingleResultOrNull(query);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/ClinicInfoDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/ClinicInfoDao.java
@@ -46,6 +46,7 @@ public class ClinicInfoDao extends AbstractDaoImpl<ClinicInfoDataObject> {
      */
     public ClinicInfoDataObject getClinic() {
         Query query = entityManager.createQuery("FROM ClinicInfoDataObject c");
+        query.setMaxResults(1);
 
         query.setMaxResults(1);
         ClinicInfoDataObject retVal = getSingleResultOrNull(query);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/DemographicExportDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/DemographicExportDao.java
@@ -71,10 +71,10 @@ public class DemographicExportDao extends AbstractDaoImpl<DemographicExport> {
     public List<DemographicExport> getAllDocumentsForPatient(int demographicNo) {
         String sql = "SELECT id, document_type, document, de.demographic_no "
                 + "FROM DemographicExport de, Demographic d "
-                + "WHERE de.demographic_no = d.demographic_no AND de.demographic_no = ?";
+                + "WHERE de.demographic_no = d.demographic_no AND de.demographic_no = ?1";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicNo);
+        query.setParameter(1, demographicNo);
 
         return query.getResultList();
     }
@@ -87,9 +87,9 @@ public class DemographicExportDao extends AbstractDaoImpl<DemographicExport> {
      */
     @SuppressWarnings("unchecked")
     public List<DemographicExport> getAllDocumentsOfType(DocumentType documentType) {
-        String sql = "FROM DemographicExport d WHERE d.documentType = ?";
+        String sql = "FROM DemographicExport d WHERE d.documentType = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, documentType.name());
+        query.setParameter(1, documentType.name());
 
         return query.getResultList();
     }
@@ -101,9 +101,9 @@ public class DemographicExportDao extends AbstractDaoImpl<DemographicExport> {
      * @return Returns a DemographicExport object.
      */
     public DemographicExport getDocument(int id) {
-        String sql = "FROM DemographicExport d WHERE d.id = ?";
+        String sql = "FROM DemographicExport d WHERE d.id = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
 
         return getSingleResultOrNull(query);
     }

--- a/src/main/java/org/oscarehr/sharingcenter/dao/EDocMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/EDocMappingDao.java
@@ -56,7 +56,7 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
     public List<EDocMapping> findByAffinityDomainId(int affinityDomain) {
         String sql = "FROM EDocMapping e where e.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
+        query.setParameter(1, affinityDomain);
 
         return query.getResultList();
     }
@@ -65,9 +65,9 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
         String sql = "FROM EDocMapping e where e.affinityDomain = ?1 and e.docType = ?2 and e.source = ?3";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, docType);
-        query.setParameter(2, source);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, docType);
+        query.setParameter(3, source);
 
         query.setMaxResults(1);
         EDocMapping retVal = getSingleResultOrNull(query);
@@ -78,8 +78,8 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
         String sql = "FROM EDocMapping e where e.affinityDomain = ?1 and e.docType = ?2";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, docType);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, docType);
 
         query.setMaxResults(1);
         EDocMapping retVal = getSingleResultOrNull(query);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/EDocMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/EDocMappingDao.java
@@ -54,7 +54,7 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
     }
 
     public List<EDocMapping> findByAffinityDomainId(int affinityDomain) {
-        String sql = "FROM EDocMapping e where e.affinityDomain = ?";
+        String sql = "FROM EDocMapping e where e.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, affinityDomain);
 
@@ -62,7 +62,7 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
     }
 
     public EDocMapping findEDocMapping(int affinityDomain, String docType, String source) {
-        String sql = "FROM EDocMapping e where e.affinityDomain = ? and e.docType = ? and e.source = ?";
+        String sql = "FROM EDocMapping e where e.affinityDomain = ?1 and e.docType = ?2 and e.source = ?3";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, affinityDomain);
@@ -75,7 +75,7 @@ public class EDocMappingDao extends AbstractDaoImpl<EDocMapping> {
     }
 
     public EDocMapping findEDocMapping(int affinityDomain, String docType) {
-        String sql = "FROM EDocMapping e where e.affinityDomain = ? and e.docType = ?";
+        String sql = "FROM EDocMapping e where e.affinityDomain = ?1 and e.docType = ?2";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, affinityDomain);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/EFormMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/EFormMappingDao.java
@@ -62,12 +62,12 @@ public class EFormMappingDao extends AbstractDaoImpl<EFormMapping> {
     }
 
     public EFormMapping findEFormMapping(int affinityDomain, int eformId, String source) {
-        String sql = "FROM EFormMapping e where e.affinityDomain = ? and e.eformId = ? and e.source = ?";
+        String sql = "FROM EFormMapping e where e.affinityDomain = ?1 and e.eformId = ?2 and e.source = ?3";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, eformId);
-        query.setParameter(2, source);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, eformId);
+        query.setParameter(3, source);
 
         query.setMaxResults(1);
         EFormMapping retVal = getSingleResultOrNull(query);
@@ -75,11 +75,11 @@ public class EFormMappingDao extends AbstractDaoImpl<EFormMapping> {
     }
 
     public EFormMapping findEFormMapping(int affinityDomain, int eformId) {
-        String sql = "FROM EFormMapping e where e.affinityDomain = ? and e.eformId = ?";
+        String sql = "FROM EFormMapping e where e.affinityDomain = ?1 and e.eformId = ?2";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, eformId);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, eformId);
 
         query.setMaxResults(1);
         EFormMapping retVal = getSingleResultOrNull(query);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/ExportedDocumentDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/ExportedDocumentDao.java
@@ -60,9 +60,9 @@ public class ExportedDocumentDao extends AbstractDaoImpl<ExportedDocument> {
      * @return ExportedDocument objects for a patient
      */
     public List<ExportedDocument> findByPatient(int demographicId) {
-        String sql = "FROM ExportedDocument e where e.demographicNo = ? ORDER BY id DESC";
+        String sql = "FROM ExportedDocument e where e.demographicNo = ?1 ORDER BY id DESC";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
         List<ExportedDocument> retVal = query.getResultList();
@@ -77,11 +77,11 @@ public class ExportedDocumentDao extends AbstractDaoImpl<ExportedDocument> {
      * @return ExportedDocument objects for a patient in an affinty domain
      */
     public List<ExportedDocument> findByPatientInDomain(int affinityDomain, int demographicId) {
-        String sql = "FROM ExportedDocument e where e.affinityDomain = ? and e.demographicNo = ? ORDER BY id DESC";
+        String sql = "FROM ExportedDocument e where e.affinityDomain = ?1 and e.demographicNo = ?2 ORDER BY id DESC";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, demographicId);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, demographicId);
 
         @SuppressWarnings("unchecked")
         List<ExportedDocument> retVal = query.getResultList();
@@ -98,12 +98,12 @@ public class ExportedDocumentDao extends AbstractDaoImpl<ExportedDocument> {
      * @return ExportedDocument documents of a specific type for a patient in an affinity domain
      */
     public List<ExportedDocument> findByTypeForPatientInDomain(int affinityDomain, int demographicId, String documentType) {
-        String sql = "FROM ExportedDocument e where e.affinityDomain = ? and e.demographicNo = ? and e.documentType = ? ORDER BY id DESC";
+        String sql = "FROM ExportedDocument e where e.affinityDomain = ?1 and e.demographicNo = ?2 and e.documentType = ?3 ORDER BY id DESC";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, demographicId);
-        query.setParameter(2, documentType);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, demographicId);
+        query.setParameter(3, documentType);
 
         @SuppressWarnings("unchecked")
         List<ExportedDocument> retVal = query.getResultList();

--- a/src/main/java/org/oscarehr/sharingcenter/dao/InfrastructureDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/InfrastructureDao.java
@@ -46,9 +46,9 @@ public class InfrastructureDao extends AbstractDaoImpl<InfrastructureDataObject>
      * @return Infrastructure or null if nothing found
      */
     public InfrastructureDataObject getInfrastructure(int id) {
-        String sql = "FROM InfrastructureDataObject i where i.id = ?";
+        String sql = "FROM InfrastructureDataObject i where i.id = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
 
         InfrastructureDataObject i = getSingleResultOrNull(query);
         return i;
@@ -64,9 +64,9 @@ public class InfrastructureDao extends AbstractDaoImpl<InfrastructureDataObject>
     }
 
     public boolean aliasExists(String alias) {
-        String sql = "SELECT count(alias) FROM InfrastructureDataObject WHERE alias = ?";
+        String sql = "SELECT count(alias) FROM InfrastructureDataObject WHERE alias = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, alias);
+        query.setParameter(1, alias);
 
         int retVal = ((Long) query.getSingleResult()).intValue();
         return retVal > 0;

--- a/src/main/java/org/oscarehr/sharingcenter/dao/MiscMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/MiscMappingDao.java
@@ -56,7 +56,7 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
     public List<MiscMapping> findByAffinityDomainId(int affinityDomain) {
         String sql = "FROM MiscMapping e where e.affinityDomain = ?";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
+        query.setParameter(1, affinityDomain);
 
         return query.getResultList();
     }
@@ -65,9 +65,9 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
         String sql = "FROM MiscMapping e where e.affinityDomain = ? and e.type = ? and e.source = ?";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, miscType);
-        query.setParameter(2, source);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, miscType);
+        query.setParameter(3, source);
 
         query.setMaxResults(1);
         MiscMapping retVal = getSingleResultOrNull(query);
@@ -78,8 +78,8 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
         String sql = "FROM MiscMapping e where e.affinityDomain = ? and e.type = ?";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, miscType);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, miscType);
 
         query.setMaxResults(1);
         MiscMapping retVal = getSingleResultOrNull(query);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/MiscMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/MiscMappingDao.java
@@ -54,7 +54,7 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
     }
 
     public List<MiscMapping> findByAffinityDomainId(int affinityDomain) {
-        String sql = "FROM MiscMapping e where e.affinityDomain = ?";
+        String sql = "FROM MiscMapping e where e.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, affinityDomain);
 
@@ -62,7 +62,7 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
     }
 
     public MiscMapping findMiscMapping(int affinityDomain, String miscType, String source) {
-        String sql = "FROM MiscMapping e where e.affinityDomain = ? and e.type = ? and e.source = ?";
+        String sql = "FROM MiscMapping e where e.affinityDomain = ?1 and e.type = ?2 and e.source = ?3";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, affinityDomain);
@@ -75,7 +75,7 @@ public class MiscMappingDao extends AbstractDaoImpl<MiscMapping> {
     }
 
     public MiscMapping findMiscMapping(int affinityDomain, String miscType) {
-        String sql = "FROM MiscMapping e where e.affinityDomain = ? and e.type = ?";
+        String sql = "FROM MiscMapping e where e.affinityDomain = ?1 and e.type = ?2";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, affinityDomain);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/PatientDocumentDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/PatientDocumentDao.java
@@ -47,9 +47,9 @@ public class PatientDocumentDao extends AbstractDaoImpl<PatientDocument> {
      * @return list of all Patient Documents
      */
     public List<PatientDocument> findPatientDocuments(int demographicId) {
-        String sql = "FROM PatientDocument e where e.demographic_no = ?";
+        String sql = "FROM PatientDocument e where e.demographic_no = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
         List<PatientDocument> retVal = query.getResultList();
@@ -65,20 +65,20 @@ public class PatientDocumentDao extends AbstractDaoImpl<PatientDocument> {
      * @return boolean whether or not the document exists
      */
     public boolean documentExists(String documentUniqueId, String repositoryUniqueId) {
-        String sql = "SELECT count(*) FROM PatientDocument e where e.uniqueDocumentId = ? AND e.repositoryUniqueId = ?";
+        String sql = "SELECT count(*) FROM PatientDocument e where e.uniqueDocumentId = ?1 AND e.repositoryUniqueId = ?2";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, documentUniqueId);
-        query.setParameter(1, repositoryUniqueId);
+        query.setParameter(1, documentUniqueId);
+        query.setParameter(2, repositoryUniqueId);
 
         int retVal = ((Long) query.getSingleResult()).intValue();
         return retVal > 0;
     }
 
     public PatientDocument getDocument(String documentUniqueId, String repositoryUniqueId) {
-        String sql = "FROM PatientDocument e where e.uniqueDocumentId = ? AND e.repositoryUniqueId = ?";
+        String sql = "FROM PatientDocument e where e.uniqueDocumentId = ?1 AND e.repositoryUniqueId = ?2";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, documentUniqueId);
-        query.setParameter(1, repositoryUniqueId);
+        query.setParameter(1, documentUniqueId);
+        query.setParameter(2, repositoryUniqueId);
 
         query.setMaxResults(1);
         PatientDocument retVal = getSingleResultOrNull(query);
@@ -92,9 +92,9 @@ public class PatientDocumentDao extends AbstractDaoImpl<PatientDocument> {
      * @return a count of the documents.
      */
     public int getDocumentCount(int demographicId) {
-        String sql = "SELECT count(*) FROM PatientDocument e where e.demographic_no = ?";
+        String sql = "SELECT count(*) FROM PatientDocument e where e.demographic_no = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
 
         int retVal = ((Long) query.getSingleResult()).intValue();
         return retVal;
@@ -110,9 +110,9 @@ public class PatientDocumentDao extends AbstractDaoImpl<PatientDocument> {
      * @return a list of PatientDocument objects
      */
     public List<PatientDocument> findPatientDocumentsWithPagination(int demographicId, int offset, int elements) {
-        String sql = "FROM PatientDocument e where e.demographic_no = ?";
+        String sql = "FROM PatientDocument e where e.demographic_no = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
         query.setFirstResult(offset);
         query.setMaxResults(elements);
 

--- a/src/main/java/org/oscarehr/sharingcenter/dao/PatientPolicyConsentDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/PatientPolicyConsentDao.java
@@ -47,19 +47,19 @@ public class PatientPolicyConsentDao extends AbstractDaoImpl<PatientPolicyConsen
     }
 
     public List<PatientPolicyConsent> findByDemographicId(int demographicId) {
-        String sql = "FROM PatientPolicyConsent e where e.demographicNo = ?";
+        String sql = "FROM PatientPolicyConsent e where e.demographicNo = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
 
         return query.getResultList();
     }
 
     public boolean isPatientConsentedToPolicy(int demographicId, int policyId) {
-        String sql = "SELECT count(*) FROM PatientPolicyConsent e where e.demographicNo = ? and e.policyId = ?";
+        String sql = "SELECT count(*) FROM PatientPolicyConsent e where e.demographicNo = ?1 and e.policyId = ?2";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
-        query.setParameter(1, policyId);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, policyId);
 
         int retVal = ((Long) query.getSingleResult()).intValue();
         return retVal > 0;

--- a/src/main/java/org/oscarehr/sharingcenter/dao/PatientSharingNetworkDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/PatientSharingNetworkDao.java
@@ -56,7 +56,7 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
     public List<PatientSharingNetworkDataObject> findByDemographicId(int demographicId) {
         String sql = "FROM PatientSharingNetworkDataObject e where e.demographicNo = ?";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, demographicId);
+        query.setParameter(1, demographicId);
 
         return query.getResultList();
     }
@@ -65,8 +65,8 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
         String sql = "FROM PatientSharingNetworkDataObject e where e.affinityDomain = ? and e.demographicNo = ?";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, demographicId);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, demographicId);
 
         query.setMaxResults(1);
         PatientSharingNetworkDataObject retVal = getSingleResultOrNull(query);
@@ -77,8 +77,8 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
         String sql = "SELECT count(*) FROM PatientSharingNetworkDataObject e where e.affinityDomain = ? and e.demographicNo = ? and e.sharingEnabled = 1";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, demographicId);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, demographicId);
 
         int retVal = ((Long) query.getSingleResult()).intValue();
         return retVal > 0;

--- a/src/main/java/org/oscarehr/sharingcenter/dao/PatientSharingNetworkDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/PatientSharingNetworkDao.java
@@ -54,7 +54,7 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
     }
 
     public List<PatientSharingNetworkDataObject> findByDemographicId(int demographicId) {
-        String sql = "FROM PatientSharingNetworkDataObject e where e.demographicNo = ?";
+        String sql = "FROM PatientSharingNetworkDataObject e where e.demographicNo = ?1";
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, demographicId);
 
@@ -62,7 +62,7 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
     }
 
     public PatientSharingNetworkDataObject findPatientSharingNetworkDataObject(int affinityDomain, int demographicId) {
-        String sql = "FROM PatientSharingNetworkDataObject e where e.affinityDomain = ? and e.demographicNo = ?";
+        String sql = "FROM PatientSharingNetworkDataObject e where e.affinityDomain = ?1 and e.demographicNo = ?2";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, affinityDomain);
@@ -74,7 +74,7 @@ public class PatientSharingNetworkDao extends AbstractDaoImpl<PatientSharingNetw
     }
 
     public boolean isSharingEnabled(int affinityDomain, int demographicId) {
-        String sql = "SELECT count(*) FROM PatientSharingNetworkDataObject e where e.affinityDomain = ? and e.demographicNo = ? and e.sharingEnabled = 1";
+        String sql = "SELECT count(*) FROM PatientSharingNetworkDataObject e where e.affinityDomain = ?1 and e.demographicNo = ?2 and e.sharingEnabled = 1";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(1, affinityDomain);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/PolicyDefinitionDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/PolicyDefinitionDao.java
@@ -48,9 +48,9 @@ public class PolicyDefinitionDao extends AbstractDaoImpl<PolicyDefinitionDataObj
      * @return PolicyDefinition
      */
     public PolicyDefinitionDataObject getPolicyDefinition(int id) {
-        String sql = "FROM PolicyDefinitionDataObject a where a.id = ?";
+        String sql = "FROM PolicyDefinitionDataObject a where a.id = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, id);
+        query.setParameter(1, id);
 
         PolicyDefinitionDataObject retVal = getSingleResultOrNull(query);
         return retVal;
@@ -65,11 +65,11 @@ public class PolicyDefinitionDao extends AbstractDaoImpl<PolicyDefinitionDataObj
      * @return PolicyDefinition
      */
     public PolicyDefinitionDataObject getPolicyDefinitionByCode(String code, String codeSystem, AffinityDomainDataObject domain) {
-        String sql = "FROM PolicyDefinitionDataObject a where a.code = ? and a.codeSystem = ? and a.affinityDomain = ?";
+        String sql = "FROM PolicyDefinitionDataObject a where a.code = ?1 and a.codeSystem = ?2 and a.affinityDomain = ?3";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, code);
-        query.setParameter(1, codeSystem);
-        query.setParameter(2, domain);
+        query.setParameter(1, code);
+        query.setParameter(2, codeSystem);
+        query.setParameter(3, domain);
 
         query.setMaxResults(1);
         PolicyDefinitionDataObject retVal = getSingleResultOrNull(query);
@@ -83,9 +83,9 @@ public class PolicyDefinitionDao extends AbstractDaoImpl<PolicyDefinitionDataObj
      * @return PolicyDefinition
      */
     public List<PolicyDefinitionDataObject> getPolicyDefinitionByDomain(AffinityDomainDataObject domain) {
-        String sql = "FROM PolicyDefinitionDataObject a where a.affinityDomain = ?";
+        String sql = "FROM PolicyDefinitionDataObject a where a.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, domain);
+        query.setParameter(1, domain);
 
         @SuppressWarnings("unchecked")
         List<PolicyDefinitionDataObject> retVal = query.getResultList();

--- a/src/main/java/org/oscarehr/sharingcenter/dao/SiteMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/SiteMappingDao.java
@@ -54,7 +54,7 @@ public class SiteMappingDao extends AbstractDaoImpl<SiteMapping> {
     }
 
     public SiteMapping findSiteMapping(int affinityDomain) {
-        String sql = "FROM SiteMapping e where e.affinityDomain = ?";
+        String sql = "FROM SiteMapping e where e.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, affinityDomain);
 
@@ -64,7 +64,7 @@ public class SiteMappingDao extends AbstractDaoImpl<SiteMapping> {
     }
 
     public SiteMapping findSiteMapping(int affinityDomain, String source) {
-        String sql = "FROM SiteMapping e where e.affinityDomain = ? and e.source = ?";
+        String sql = "FROM SiteMapping e where e.affinityDomain = ?1 and e.source = ?2";
 
         Query query = entityManager.createQuery(sql);
         query.setParameter(0, affinityDomain);

--- a/src/main/java/org/oscarehr/sharingcenter/dao/SiteMappingDao.java
+++ b/src/main/java/org/oscarehr/sharingcenter/dao/SiteMappingDao.java
@@ -56,7 +56,7 @@ public class SiteMappingDao extends AbstractDaoImpl<SiteMapping> {
     public SiteMapping findSiteMapping(int affinityDomain) {
         String sql = "FROM SiteMapping e where e.affinityDomain = ?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
+        query.setParameter(1, affinityDomain);
 
         query.setMaxResults(1);
         SiteMapping retVal = getSingleResultOrNull(query);
@@ -67,8 +67,8 @@ public class SiteMappingDao extends AbstractDaoImpl<SiteMapping> {
         String sql = "FROM SiteMapping e where e.affinityDomain = ?1 and e.source = ?2";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(0, affinityDomain);
-        query.setParameter(1, source);
+        query.setParameter(1, affinityDomain);
+        query.setParameter(2, source);
 
         query.setMaxResults(1);
         SiteMapping retVal = getSingleResultOrNull(query);

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/BillingHistoryDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/BillingHistoryDAO.java
@@ -145,8 +145,8 @@ public class BillingHistoryDAO {
      */
     private BillHistory getCurrentBillItemState(String billMasterNo) {
         BillHistory history = null;
-        String bmQuery = "SELECT b.provider_no, b.billingtype,bm.billingstatus, bm.bill_amount,bm.paymentMethod FROM billing b, billingmaster bm " + " WHERE b.billing_no=bm.billing_no AND bm.billingmaster_no = " + billMasterNo;
-        List billValues = SqlUtils.getQueryResultsList(bmQuery);
+        String bmQuery = "SELECT b.provider_no, b.billingtype,bm.billingstatus, bm.bill_amount,bm.paymentMethod FROM billing b, billingmaster bm " + " WHERE b.billing_no=bm.billing_no AND bm.billingmaster_no = ?1";
+        List billValues = SqlUtils.getQueryResultsList(bmQuery, billMasterNo);
         if (billValues != null) {
             history = new BillHistory();
             String[] values = (String[]) billValues.get(0);

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/BillingPreferencesDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/BillingPreferencesDAO.java
@@ -47,8 +47,8 @@ public class BillingPreferencesDAO extends AbstractDaoImpl<BillingPreference> {
 
     @SuppressWarnings("unchecked")
     public BillingPreference getUserBillingPreference(String providerNo) {
-        Query query = createQuery("bp", "bp.providerNo = :providerNo");
-        query.setParameter("providerNo", providerNo);
+        Query query = createQuery("bp", "bp.providerNo = ?1");
+        query.setParameter(1, providerNo);
 
         List<BillingPreference> prefs = query.getResultList();
         if (prefs.isEmpty()) return null;

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/BillingmasterDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/BillingmasterDAO.java
@@ -267,8 +267,8 @@ public class BillingmasterDAO {
     }
 
     public List<Billing> search_teleplanbill(Integer billingmasterNo) {
-        Query q = entityManager.createQuery("select b from Billing b, Billingmaster bm where b.id= bm.billingNo and bm.billingmasterNo=?");
-        q.setParameter(0, billingmasterNo);
+        Query q = entityManager.createQuery("select b from Billing b, Billingmaster bm where b.id= bm.billingNo and bm.billingmasterNo=?1");
+        q.setParameter(1, billingmasterNo);
 
         @SuppressWarnings("unchecked")
         List<Billing> results = q.getResultList();
@@ -302,8 +302,8 @@ public class BillingmasterDAO {
     }
 
     public List<Object[]> getRecentReferralDoctors(Integer demographicNo) {
-        Query query = entityManager.createQuery("SELECT referralNo1, referralNo2 FROM Billingmaster WHERE demographic_no = ? AND (referralNo1!='' OR referralNo2!='') ORDER BY billingmasterNo DESC");
-        query.setParameter(0, demographicNo);
+        Query query = entityManager.createQuery("SELECT referralNo1, referralNo2 FROM Billingmaster WHERE demographic_no = ?1 AND (referralNo1!='' OR referralNo2!='') ORDER BY billingmasterNo DESC");
+        query.setParameter(1, demographicNo);
         return query.setMaxResults(3).getResultList();
     }
 

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/PrivateBillTransactionsDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/PrivateBillTransactionsDAO.java
@@ -54,9 +54,8 @@ public class PrivateBillTransactionsDAO extends AbstractDaoImpl<BillingPrivateTr
     @SuppressWarnings("unchecked")
     // TODO Annotate with @NativeSql({"billing_private_transactions", "billing_payment_type"}) query when the commit is merged into the main codebase
     public List<PrivateBillTransaction> getPrivateBillTransactions(String billingmaster_no) {
-        Query query = entityManager.createNativeQuery("select bp.id, billingmaster_no, amount_received, creation_date, payment_type_id, bt.payment_type as 'payment_type_desc'" + " from billing_private_transactions bp,billing_payment_type bt where bp.billingmaster_no = ?1 and bp.payment_type_id = ?2");
-        query.setParameter(1, ConversionUtils.fromIntString(billingmaster_no));
-        query.setParameter(2, ConversionUtils.fromIntString(billingmaster_no));
+       Query query = entityManager.createNativeQuery("select bp.id, billingmaster_no, amount_received, creation_date, payment_type_id, bt.payment_type as 'payment_type_desc'" + " from billing_private_transactions bp,billing_payment_type bt where bp.billingmaster_no = :billingmasterNo and bp.payment_type_id = bt.id");
+        query.setParameter("billingmasterNo", ConversionUtils.fromIntString(billingmaster_no));
         List<Object[]> resultList = query.getResultList();
         List<PrivateBillTransaction> result = new ArrayList<PrivateBillTransaction>();
         for (Object[] res : resultList) {

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/PrivateBillTransactionsDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/PrivateBillTransactionsDAO.java
@@ -54,8 +54,9 @@ public class PrivateBillTransactionsDAO extends AbstractDaoImpl<BillingPrivateTr
     @SuppressWarnings("unchecked")
     // TODO Annotate with @NativeSql({"billing_private_transactions", "billing_payment_type"}) query when the commit is merged into the main codebase
     public List<PrivateBillTransaction> getPrivateBillTransactions(String billingmaster_no) {
-        Query query = entityManager.createNativeQuery("select bp.id, billingmaster_no, amount_received, creation_date, payment_type_id, bt.payment_type as 'payment_type_desc'" + " from billing_private_transactions bp,billing_payment_type bt where bp.billingmaster_no = :billingmasterNo and bp.payment_type_id = bt.id");
-        query.setParameter("billingmasterNo", ConversionUtils.fromIntString(billingmaster_no));
+        Query query = entityManager.createNativeQuery("select bp.id, billingmaster_no, amount_received, creation_date, payment_type_id, bt.payment_type as 'payment_type_desc'" + " from billing_private_transactions bp,billing_payment_type bt where bp.billingmaster_no = ?1 and bp.payment_type_id = ?2");
+        query.setParameter(1, ConversionUtils.fromIntString(billingmaster_no));
+        query.setParameter(2, ConversionUtils.fromIntString(billingmaster_no));
         List<Object[]> resultList = query.getResultList();
         List<PrivateBillTransaction> result = new ArrayList<PrivateBillTransaction>();
         for (Object[] res : resultList) {

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/SupServiceCodeAssocDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/SupServiceCodeAssocDAO.java
@@ -111,8 +111,8 @@ public class SupServiceCodeAssocDAO extends AbstractDaoImpl<BillingTrayFee> {
         String primaryCodeId = getBillingServiceValue(primaryCode, SupServiceCodeAssocDAO.VALUE_BY_CODE);
         String secondaryCodeId = getBillingServiceValue(secondaryCode, SupServiceCodeAssocDAO.VALUE_BY_CODE);
 
-        Query query = createQuery("btf", "btf.billingServiceNo = :billingServiceNo");
-        query.setParameter("billingServiceNo", primaryCodeId);
+        Query query = createQuery("btf", "btf.billingServiceNo = ?1");
+        query.setParameter(1, primaryCodeId);
 
         BillingTrayFee btf = null;
         for (BillingTrayFee b : (List<BillingTrayFee>) query.getResultList()) {
@@ -152,7 +152,7 @@ public class SupServiceCodeAssocDAO extends AbstractDaoImpl<BillingTrayFee> {
         }
 
         Query query = entityManager.createQuery(queryString);
-        query.setParameter("param", queryParam);
+        query.setParameter(1, queryParam);
 
         List<BillingService> billingServices = query.getResultList();
         if (billingServices.isEmpty()) return "";

--- a/src/main/java/oscar/oscarBilling/ca/bc/data/SupServiceCodeAssocDAO.java
+++ b/src/main/java/oscar/oscarBilling/ca/bc/data/SupServiceCodeAssocDAO.java
@@ -142,10 +142,10 @@ public class SupServiceCodeAssocDAO extends AbstractDaoImpl<BillingTrayFee> {
         Object queryParam = null;
 
         if (type == SupServiceCodeAssocDAO.VALUE_BY_CODE) {
-            queryString = "FROM BillingService bs WHERE bs.serviceCode = :param";
+            queryString = "FROM BillingService bs WHERE bs.serviceCode = ?1";
             queryParam = code;
         } else if (type == SupServiceCodeAssocDAO.VALUE_BY_ID) {
-            queryString = "FROM BillingService bs WHERE bs.billingserviceNo = :param";
+            queryString = "FROM BillingService bs WHERE bs.billingserviceNo = ?1";
             queryParam = ConversionUtils.fromIntString(code);
         } else {
             throw new IllegalArgumentException("Unsupported type" + type);


### PR DESCRIPTION
Subdirs with dao folders (dao files) that I ran the Aider script with:

1. oscarehr\sharingcenter
2. oscarehr\phr
3. oscarehr\olis
4. oscarehr\hospitalReportManager
5. oscarehr\PMmodule 
6. oscarehr\eyeform 
7. oscarehr\casemgmt 

I assumed that the other subdirs (ie. _common_ was done by Seb - he told me he's doing it, _billing_ was done my Michael - I checked the PR)

Note: this is a **new** branch that I cherry picked the valid commits to. I have a different branch where all of the aider commits includes both valid and invalid (as I already pushed the commits before learning to exclude the Hibernate query).

## Summary by Sourcery

Fix positional parameter usage in JPA queries by updating parameter indices from zero-based to one-based across various DAO classes to ensure compatibility with JPA standards.

Bug Fixes:
- Fix positional parameter usage in JPA queries by replacing zero-based parameter indices with one-based indices across multiple DAO classes.