### PR TITLE
Hibernate api update

### DIFF
--- a/src/main/java/com/quatro/dao/LookupDaoImpl.java
+++ b/src/main/java/com/quatro/dao/LookupDaoImpl.java
@@ -239,13 +239,9 @@ public class LookupDaoImpl extends HibernateDaoSupport implements LookupDao {
 
     @Override
     public LookupTableDefValue GetLookupTableDef(String tableId) {
-        ArrayList<String> paramList = new ArrayList<String>();
-
-        String sSQL = "from LookupTableDefValue s where s.tableId= ?";
-        paramList.add(tableId);
-        Object params[] = paramList.toArray(new Object[paramList.size()]);
+        String sSQL = "from LookupTableDefValue s where s.tableId= ?0";
         try {
-            return (LookupTableDefValue) getHibernateTemplate().find(sSQL, params).get(0);
+            return (LookupTableDefValue) getHibernateTemplate().find(sSQL, new Object[]{tableId}).get(0);
         } catch (Exception ex) {
             MiscUtils.getLogger().error("Error", ex);
             return null;
@@ -254,7 +250,7 @@ public class LookupDaoImpl extends HibernateDaoSupport implements LookupDao {
 
     @Override
     public List LoadFieldDefList(String tableId) {
-        String sSql = "from FieldDefValue s where s.tableId=? order by s.fieldIndex ";
+        String sSql = "from FieldDefValue s where s.tableId=?0 order by s.fieldIndex ";
         ArrayList<String> paramList = new ArrayList<String>();
         paramList.add(tableId);
         Object params[] = paramList.toArray(new Object[paramList.size()]);
@@ -605,10 +601,10 @@ public class LookupDaoImpl extends HibernateDaoSupport implements LookupDao {
     private void updateOrgStatus(String orgCd, LookupCodeValue newCd) {
         LookupCodeValue oldCd = GetCode("ORG", orgCd);
         if (!newCd.isActive()) {
-            String oldCsv = oldCd.getCodecsv();
+            String oldCsv = oldCd.getCodecsv() + "_%";
 
             List<LstOrgcd> o = (List<LstOrgcd>) this.getHibernateTemplate()
-                    .find("FROM LstOrgcd o WHERE o.codecsv like ?", oldCsv + "_%");
+                    .find("FROM LstOrgcd o WHERE o.codecsv like ?0", oldCsv);
             for (LstOrgcd l : o) {
                 l.setActiveyn(0);
                 this.getHibernateTemplate().update(l);
@@ -619,7 +615,7 @@ public class LookupDaoImpl extends HibernateDaoSupport implements LookupDao {
     @Override
     public boolean inOrg(String org1, String org2) {
         boolean isInString = false;
-        String sql = "From LstOrgcd a where  a.fullcode like '%" + "?'  ";
+        String sql = "From LstOrgcd a where  a.fullcode like %?0";
 
         LstOrgcd orgObj1 = (LstOrgcd) getHibernateTemplate().find(sql, new Object[]{org1});
         LstOrgcd orgObj2 = (LstOrgcd) getHibernateTemplate().find(sql, new Object[]{org2});

--- a/src/main/java/com/quatro/dao/security/SecProviderDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/SecProviderDaoImpl.java
@@ -98,7 +98,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
     public SecProvider findById(java.lang.String id, String status) {
         logger.debug("getting Provider instance with id: " + id);
         try {
-            String sql = "from SecProvider where id=? and status=?";
+            String sql = "from SecProvider where id=?0 and status=?1";
             List lst = this.getHibernateTemplate().find(sql, new Object[]{id, status});
             if (lst.size() == 0)
                 return null;
@@ -138,9 +138,9 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         Session session = getSession();
         try {
             String queryString = "from Provider as model where model."
-                    + propertyName + "= ?";
+                    + propertyName + "= ?1";
             Query queryObject = session.createQuery(queryString);
-            queryObject.setParameter(0, value);
+            queryObject.setParameter(1, value);
             return queryObject.list();
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);

--- a/src/main/java/com/quatro/dao/security/SecobjprivilegeDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/SecobjprivilegeDaoImpl.java
@@ -117,7 +117,7 @@ public class SecobjprivilegeDaoImpl extends HibernateDaoSupport implements Secob
         logger.debug("deleting Secobjprivilege by roleName");
         try {
 
-            return getHibernateTemplate().bulkUpdate("delete Secobjprivilege as model where model.roleusergroup =?",
+            return getHibernateTemplate().bulkUpdate("delete Secobjprivilege as model where model.roleusergroup =?0",
                     roleName);
 
         } catch (RuntimeException re) {
@@ -192,9 +192,9 @@ public class SecobjprivilegeDaoImpl extends HibernateDaoSupport implements Secob
         Session session = sessionFactory.getCurrentSession();
         try {
             String queryString = "from Secobjprivilege as model where model."
-                    + propertyName + "= ? order by objectname_code";
+                    + propertyName + "= ?1 order by objectname_code";
             Query queryObject = session.createQuery(queryString);
-            queryObject.setParameter(0, value);
+            queryObject.setParameter(1, value);
             return queryObject.list();
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);
@@ -223,13 +223,13 @@ public class SecobjprivilegeDaoImpl extends HibernateDaoSupport implements Secob
 
     @Override
     public List<Secobjprivilege> getByRoles(List<String> roles) {
-        String queryString = "from Secobjprivilege obj where obj.roleusergroup IN (:roles)";
+        String queryString = "from Secobjprivilege obj where obj.roleusergroup IN (?1)";
         List<Secobjprivilege> results = new ArrayList<Secobjprivilege>();
 
         Session session = sessionFactory.getCurrentSession();
         Query q = session.createQuery(queryString);
 
-        q.setParameterList("roles", roles);
+        q.setParameterList(1, roles);
 
         results = q.list();
 

--- a/src/main/java/com/quatro/dao/security/SecuserroleDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/SecuserroleDaoImpl.java
@@ -146,7 +146,7 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
         logger.debug("deleting Secuserrole by orgcd");
         try {
 
-            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.orgcd =?", orgcd);
+            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.orgcd =?0", orgcd);
 
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -159,7 +159,7 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
         logger.debug("deleting Secuserrole by providerNo");
         try {
 
-            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.providerNo =?",
+            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.providerNo =?0",
                     providerNo);
 
         } catch (RuntimeException re) {
@@ -173,7 +173,7 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
         logger.debug("deleting Secuserrole by ID");
         try {
 
-            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.id =?", id);
+            return getHibernateTemplate().bulkUpdate("delete Secuserrole as model where model.id =?0", id);
 
         } catch (RuntimeException re) {
             logger.error("delete failed", re);
@@ -255,9 +255,9 @@ public class SecuserroleDaoImpl extends HibernateDaoSupport implements Secuserro
         ;
         try {
             String queryString = "from Secuserrole as model where model."
-                    + propertyName + "= ?";
+                    + propertyName + "= ?1";
             Query queryObject = session.createQuery(queryString);
-            queryObject.setParameter(0, value);
+            queryObject.setParameter(1, value);
             return queryObject.list();
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);

--- a/src/main/java/com/quatro/dao/security/UserAccessDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/UserAccessDaoImpl.java
@@ -35,10 +35,10 @@ public class UserAccessDaoImpl extends HibernateDaoSupport implements UserAccess
         String sSQL = "";
         if (shelterId != null && shelterId.intValue() > 0) {
             String s = "'%S" + shelterId.toString() + ",%'";
-            sSQL = "from UserAccessValue s where s.providerNo= ? " +
+            sSQL = "from UserAccessValue s where s.providerNo= ?0 " +
                     " and s.orgCdcsv like " + s + " order by s.functionCd, s.privilege desc, s.orgCd";
         } else {
-            sSQL = "from UserAccessValue s where s.providerNo= ? " +
+            sSQL = "from UserAccessValue s where s.providerNo= ?0 " +
                     " order by s.functionCd, s.privilege desc, s.orgCd";
         }
         return getHibernateTemplate().find(sSQL, providerNo);
@@ -49,12 +49,12 @@ public class UserAccessDaoImpl extends HibernateDaoSupport implements UserAccess
         String sSQL = "";
         if (shelterId != null && shelterId.intValue() > 0) {
             sSQL = "select distinct o.codecsv from UserAccessValue s, LstOrgcd o " +
-                    "where s.providerNo= ? and s.privilege>='r' and s.orgCd=o.code " +
+                    "where s.providerNo= ?0 and s.privilege>='r' and s.orgCd=o.code " +
                     " and o.codecsv like '%S" + shelterId.toString() + ",%'" +
                     " order by o.codecsv";
             return getHibernateTemplate().find(sSQL, providerNo);
         } else {
-            sSQL = "select distinct o.codecsv from UserAccessValue s, LstOrgcd o where s.providerNo= ? and s.privilege>='r' and s.orgCd=o.code order by o.codecsv";
+            sSQL = "select distinct o.codecsv from UserAccessValue s, LstOrgcd o where s.providerNo= ?0 and s.privilege>='r' and s.orgCd=o.code order by o.codecsv";
             return getHibernateTemplate().find(sSQL, providerNo);
         }
     }

--- a/src/main/java/org/caisi/dao/BedProgramDaoImpl.java
+++ b/src/main/java/org/caisi/dao/BedProgramDaoImpl.java
@@ -56,7 +56,7 @@ public class BedProgramDaoImpl extends HibernateDaoSupport implements BedProgram
     }
 
     public List getAllBedProgram() {
-        String qr = "FROM Program p where p.type = ?";
+        String qr = "FROM Program p where p.type = ?0";
         List rs = getProgramResultList(qr, bedType);
         return rs;
     }
@@ -80,7 +80,7 @@ public class BedProgramDaoImpl extends HibernateDaoSupport implements BedProgram
     }
 
     public List getProgramIdByName(String name) {
-        String q = "SELECT p.id FROM Program p WHERE p.name = ?";
+        String q = "SELECT p.id FROM Program p WHERE p.name = ?0";
         List rs = getProgramResultList(q, name);
         return rs;
     }

--- a/src/main/java/org/caisi/dao/ProviderDAOImpl.java
+++ b/src/main/java/org/caisi/dao/ProviderDAOImpl.java
@@ -49,7 +49,7 @@ public class ProviderDAOImpl extends HibernateDaoSupport implements ProviderDAO 
     }
 
     public Provider getProviderByName(String lastName, String firstName) {
-        return (Provider) getHibernateTemplate().find("from Provider p where p.first_name = ? and p.last_name = ?", new Object[]{firstName, lastName}).get(0);
+        return (Provider) getHibernateTemplate().find("from Provider p where p.first_name = ?0 and p.last_name = ?1", firstName, lastName).get(0);
     }
 
 }


### PR DESCRIPTION
## Changes made
- Update positional parameters in `src/main/java/com/quatro/` directory.
  - Update queries to use positional parameters starting from 1 if setParameter is used.
  - Otherwise use positional parameters starting from 0, since these classes use the old Hibernate library.
    - This will be fixed when we upgrade to Hibernate 6 and refacter these daos to use JPA style queries.

## Summary by Sourcery

Update Hibernate queries across multiple DAO implementations to use consistent positional parameter indexing, preparing for future upgrades to Hibernate 6.

Enhancements:
- Update Hibernate queries to use positional parameters starting from 0 or 1, depending on the method used, to align with the current Hibernate library version.