### PR TITLE
Hibernate upgrade pmmodule

### DIFF
--- a/src/main/java/org/oscarehr/PMmodule/dao/DefaultRoleAccessDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/DefaultRoleAccessDAOImpl.java
@@ -56,7 +56,8 @@ public class DefaultRoleAccessDAOImpl extends HibernateDaoSupport implements Def
     }
 
     public DefaultRoleAccess find(Long roleId, Long accessTypeId) {
-        List results = this.getHibernateTemplate().find("from DefaultRoleAccess dra where dra.roleId=? and dra.accessTypeId=?", new Object[]{roleId, accessTypeId});
+        String sSQL = "from DefaultRoleAccess dra where dra.roleId=?0 and dra.accessTypeId=?1";
+        List results = this.getHibernateTemplate().find(sSQL, new Object[]{roleId, accessTypeId});
 
         if (!results.isEmpty()) {
             return (DefaultRoleAccess) results.get(0);

--- a/src/main/java/org/oscarehr/PMmodule/dao/FormsDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/FormsDAOImpl.java
@@ -61,7 +61,8 @@ public class FormsDAOImpl extends HibernateDaoSupport implements FormsDAO {
         if (className.indexOf(".") != -1) {
             className = className.substring(className.lastIndexOf(".") + 1);
         }
-        List results = this.getHibernateTemplate().find("from " + className + " f where f.DemographicNo=" + clientId);
+        String sSQL = "from ?0 f where f.DemographicNo=?1";
+        List results = this.getHibernateTemplate().find(sSQL, new Object[]{className, clientId});
         if (results.size() > 0) {
             result = results.get(0);
         }
@@ -83,7 +84,12 @@ public class FormsDAOImpl extends HibernateDaoSupport implements FormsDAO {
         if (className.indexOf(".") != -1) {
             className = className.substring(className.lastIndexOf(".") + 1);
         }
-        List results = this.getHibernateTemplate().find("select f.id,f.ProviderNo,f.FormEdited from " + className + " f where f.DemographicNo=? order by f.FormEdited DESC", Long.valueOf(clientId));
+        String sSQL = "select f.id,f.ProviderNo,f.FormEdited from ?0 f where f.DemographicNo=?1 order by f.FormEdited DESC";
+        Object[] params = new Object[] {
+            className,
+            Long.valueOf(clientId)
+        };
+        List results = this.getHibernateTemplate().find(sSQL, params);
         for (Iterator iter = results.iterator(); iter.hasNext(); ) {
             FormInfo fi = new FormInfo();
             Object[] values = (Object[]) iter.next();

--- a/src/main/java/org/oscarehr/PMmodule/dao/GenericIntakeDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/GenericIntakeDAOImpl.java
@@ -66,12 +66,12 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
 
     private static final Logger LOG = MiscUtils.getLogger();
 
+    String sSQL = "from Intake i, IntakeNode n, IntakeNodeLabel l where " +
+    "i.createdOn > ?0 and i.node.id = n.id and n.label.id = l.id and " +
+    "(l.label like '%OCAN Staff Assessment%' or l.label like '%OCAN Client Self Assessment%') order by i.createdOn desc";
     @SuppressWarnings("unchecked")
     public List<Object[]> getOcanIntakesAfterDate(Calendar after) {
-        return (List<Object[]>) getHibernateTemplate().find("from Intake i, IntakeNode n, IntakeNodeLabel l where " +
-                        "i.createdOn > ? and i.node.id = n.id and n.label.id = l.id and " +
-                        "(l.label like '%OCAN Staff Assessment%' or l.label like '%OCAN Client Self Assessment%') order by i.createdOn desc",
-                new Object[]{after});
+        return (List<Object[]>) getHibernateTemplate().find(sSQL, new Object[]{after});
     }
 
     public Intake getLatestIntakeByFacility(IntakeNode node, Integer clientId, Integer programId, Integer facilityId) {
@@ -104,8 +104,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameter facilityId must be non-null");
         }
 
-        List<Integer> clientIds = (List<Integer>) getHibernateTemplate().find("select distinct i.clientId from Intake i where i.facilityId = ? order by i.clientId",
-                new Object[]{facilityId});
+        String sSQL = "select distinct i.clientId from Intake i where i.facilityId = ?0 order by i.clientId";
+        List<Integer> clientIds = (List<Integer>) getHibernateTemplate().find(sSQL, new Object[]{facilityId});
 
         return clientIds;
     }
@@ -122,8 +122,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters node and clientId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.node = ? and i.clientId = ? and (i.facilityId=? or i.facilityId is null) order by i.createdOn desc",
-                new Object[]{node, clientId, facilityId});
+        String sSQL = "from Intake i where i.node = ?0 and i.clientId = ?1 and (i.facilityId=?2 or i.facilityId is null) order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{node, clientId, facilityId});
         List<Intake> intakes = convertToIntakes(results, programId);
 
         LOG.info("get intakes: " + intakes.size());
@@ -144,8 +144,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
         List<IntakeNode> nodes = this.getIntakeNodesByType(formType);
 
         for (IntakeNode node : nodes) {
-            List<?> results = getHibernateTemplate().find("from Intake i where i.node = ? and i.clientId = ? and (i.facilityId=? or i.facilityId is null) order by i.createdOn desc",
-                    new Object[]{node, clientId, facilityId});
+            String sSQL = "from Intake i where i.node = ?0 and i.clientId = ?1 and (i.facilityId=?2 or i.facilityId is null) order by i.createdOn desc";
+            List<?> results = getHibernateTemplate().find(sSQL, new Object[]{node, clientId, facilityId});
             List<Intake> intakes = convertToIntakes(results, programId);
             intake_results.addAll(intakes);
         }
@@ -159,8 +159,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters node and clientId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.node = ? and i.clientId = ? and i.facilityId =? order by i.createdOn desc",
-                new Object[]{node, clientId, facilityId});
+        String sSQL = "from Intake i where i.node = ?0 and i.clientId = ?1 and i.facilityId =?2 order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{node, clientId, facilityId});
         List<Intake> intakes = convertToIntakes(results, programId);
 
         LOG.info("get intakes: " + intakes.size());
@@ -173,13 +173,13 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters nodes and clientId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.node = ? and i.clientId = ? and (i.facilityId=? or i.facilityId is null) order by i.createdOn desc",
-                new Object[]{nodes.get(0), clientId, facilityId});
+        String resultQuery = "from Intake i where i.node = ?0 and i.clientId = ?1 and (i.facilityId=?2 or i.facilityId is null) order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(resultQuery, new Object[]{nodes.get(0), clientId, facilityId});
         List<Intake> intakes = convertToIntakes(results, programId);
 
         for (int i = 1; i < nodes.size(); i++) {
-            results = getHibernateTemplate().find("from Intake i where i.node = ? and i.clientId = ? and (i.facilityId=? or i.facilityId is null) order by i.createdOn desc",
-                    new Object[]{nodes.get(i), clientId, facilityId});
+            String sSQL = "from Intake i where i.node = ?0 and i.clientId = ?1 and (i.facilityId=?2 or i.facilityId is null) order by i.createdOn desc";
+            results = getHibernateTemplate().find(sSQL, new Object[]{nodes.get(i), clientId, facilityId});
             intakes.addAll(convertToIntakes(results, programId));
         }
 
@@ -192,8 +192,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters node and intakeId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.node = ? and i.id = ? and (i.facilityId=? or i.facilityId is null) order by i.createdOn desc",
-                new Object[]{node, intakeId, facilityId});
+        String sSQL = "from Intake i where i.node = ?0 and i.id = ?1 and (i.facilityId=?2 or i.facilityId is null) order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{node, intakeId, facilityId});
         List<Intake> intakes = convertToIntakes(results, programId);
         LOG.info("get intakes: " + intakes.size());
         Intake intake = !intakes.isEmpty() ? intakes.get(0) : null;
@@ -206,8 +206,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters intakeId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.id = ? order by i.createdOn desc",
-                new Object[]{intakeId});
+        String sSQL = "from Intake i where i.id = ?0 order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{intakeId});
         List<Intake> intakes = convertToIntakes(results, null);
         LOG.info("get intakes: " + intakes.size());
         Integer intakeNodeId = !intakes.isEmpty() ? intakes.get(0).getNode().getId() : null;
@@ -224,8 +224,8 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
             throw new IllegalArgumentException("Parameters intakeId must be non-null");
         }
 
-        List<?> results = getHibernateTemplate().find("from Intake i where i.clientId = ? order by i.createdOn desc",
-                new Object[]{clientId});
+        String sSQL = "from Intake i where i.clientId = ?0 order by i.createdOn desc";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{clientId});
         List<Intake> intakes = convertToIntakes(results, null);
         LOG.info("get intakes: " + intakes.size());
 
@@ -305,17 +305,9 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
         Calendar startCal = new GregorianCalendar();
         startCal.setTime(startDate);
 
-        // wrong, only got the oldest first record: List<?> results = getHibernateTemplate().find("select i.id, max(i.createdOn) from Intake i where i.node.id =
-        // ? and i.createdOn between ? and ? group by i.clientId", new Object[] { nodeId, startDate, endDate });
-        //List<?> results = getHibernateTemplate()
-        //		.find(
-        //				"select i.id, max(i.createdOn) from Intake i where i.node.id = ? and i.createdOn between ? and ? and i.createdOn = (select max(ii.createdOn) from Intake ii where ii.clientId = i.clientId) group by i.clientId",
-        //				new Object[] { nodeId, startCal.getTime(), endCal.getTime() });
-
-        List<?> results = getHibernateTemplate()
-                .find(
-                        "select i.id, i.createdOn from Intake i where i.node.id = ? and i.createdOn between ? and ? and i.createdOn = (select max(ii.createdOn) from Intake ii where ii.clientId = i.clientId group by ii.clientId)",
-                        new Object[]{nodeId, startCal, endCal});
+        String sSQL = "select i.id, i.createdOn from Intake i where i.node.id = ?0 and i.createdOn between ?1 and ?2" + 
+        "and i.createdOn = (select max(ii.createdOn) from Intake ii where ii.clientId = i.clientId group by ii.clientId)";
+        List<?> results = getHibernateTemplate().find(sSQL, new Object[]{nodeId, startCal, endCal});
 
 
         SortedSet<Integer> intakeIds = convertToIntegers(results);
@@ -333,9 +325,13 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
         SortedMap<Integer, SortedMap<String, ReportStatistic>> reportStatistics = new TreeMap<Integer, SortedMap<String, ReportStatistic>>();
 
         if (!intakeIds.isEmpty() && !answerIds.isEmpty()) {
-            List<?> results = getHibernateTemplate().find(
-                    "select ia.node.id, ia.value, count(ia.value) from IntakeAnswer ia where ia.node.id in (" + convertToString(answerIds.keySet())
-                            + ") and ia.intake.id in (" + convertToString(intakeIds) + ") group by ia.node.id, ia.value");
+            String sSQL = "select ia.node.id, ia.value, count(ia.value) from IntakeAnswer ia where ia.node.id in (?0)" +
+            "and ia.intake.id in (?1) group by ia.node.id, ia.value";
+            Object[] params = new Object[] {
+                convertToString(answerIds.keySet()),
+                convertToString(intakeIds)
+            };
+            List<?> results = getHibernateTemplate().find(sSQL, params);
             convertToReportStatistics(results, intakeIds.size(), reportStatistics, answerIds);
         }
         LOG.info("get reportStatistics: " + reportStatistics.size());
@@ -454,6 +450,7 @@ public class GenericIntakeDAOImpl extends HibernateDaoSupport implements Generic
 
 
     public List<IntakeNode> getIntakeNodesByType(Integer formType) {
-        return (List<IntakeNode>) this.getHibernateTemplate().find("From IntakeNode n where n.formType = ? and n.publish_by is not null", new Object[]{formType});
+        String sSQL = "From IntakeNode n where n.formType = ?0 and n.publish_by is not null";
+        return (List<IntakeNode>) this.getHibernateTemplate().find(sSQL, new Object[]{formType});
     }
 }

--- a/src/main/java/org/oscarehr/PMmodule/dao/GenericIntakeNodeDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/GenericIntakeNodeDAOImpl.java
@@ -92,12 +92,10 @@ public class GenericIntakeNodeDAOImpl extends HibernateDaoSupport implements Gen
      * Returns a list of Intake Nodes of type "intake".
      */
     public List<IntakeNode> getPublishedIntakeNodesByName(String name) {
-        // List l =
-        // getHibernateTemplate().find("from IntakeNode i, IntakeNodeType iType, IntakeNodeTemplate iTemplate  where iType.type = 'intake'  and iType.intake_node_type_id = iTemplate.intake_node_type_id and i.intake_node_template_id = iTemplate.intake_node_template_id");
-        List<IntakeNode> l = (List<IntakeNode>) getHibernateTemplate()
-                .find(
-                        "select i from IntakeNode i, IntakeNodeType iType, IntakeNodeTemplate iTemplate, IntakeNodeLabel iLabel  where iType.type = 'intake'  and iType.id = iTemplate.type and i.nodeTemplate = iTemplate.id and i.label = iLabel.id and i.publish_date != null and iLabel.label = ? order by i.form_version desc",
-                        new Object[]{name});
+        String sSQL = "select i from IntakeNode i, IntakeNodeType iType, IntakeNodeTemplate iTemplate, IntakeNodeLabel iLabel" +
+        "where iType.type = 'intake'  and iType.id = iTemplate.type and i.nodeTemplate = iTemplate.id and i.label = iLabel.id" +
+        " and i.publish_date != null and iLabel.label = 0 order by i.form_version desc";
+        List<IntakeNode> l = (List<IntakeNode>) getHibernateTemplate().find(sSQL, new Object[]{name});
 
         // from IntakeNode i where i.type = 'intake'");
         return l;

--- a/src/main/java/org/oscarehr/PMmodule/dao/HealthSafetyDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/HealthSafetyDaoImpl.java
@@ -43,7 +43,8 @@ public class HealthSafetyDaoImpl extends HibernateDaoSupport implements HealthSa
 
         HealthSafety result = null;
 
-        List list = this.getHibernateTemplate().find("from HealthSafety c where c.demographicNo=? order by c.updateDate desc", demographicNo);
+        String sSQL = "from HealthSafety c where c.demographicNo=?0 order by c.updateDate desc";
+        List list = this.getHibernateTemplate().find(sSQL, demographicNo);
         if (!list.isEmpty()) result = (HealthSafety) list.get(0);
 
         if (log.isDebugEnabled()) {

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramAccessDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramAccessDAOImpl.java
@@ -83,9 +83,8 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
         }
         String accessTypeIdString = accessTypeId.toString();
         ProgramAccess result = null;
-        List results = this.getHibernateTemplate().find(
-                "from ProgramAccess pa where pa.ProgramId = ? and pa.AccessTypeId = ?",
-                new Object[]{programId, accessTypeIdString});
+        String sSQL = "from ProgramAccess pa where pa.ProgramId = ?0 and pa.AccessTypeId = ?1";
+        List results = this.getHibernateTemplate().find(sSQL, new Object[]{programId, accessTypeIdString});
         if (results.size() > 0) {
             result = (ProgramAccess) results.get(0);
         }
@@ -101,7 +100,7 @@ public class ProgramAccessDAOImpl extends HibernateDaoSupport implements Program
     @SuppressWarnings("unchecked")
     @Override
     public List<ProgramAccess> getProgramAccessListByType(Long programId, String accessType) {
-        String q = "from ProgramAccess pa where pa.ProgramId = ? and pa.AccessType.Name like ?";
+        String q = "from ProgramAccess pa where pa.ProgramId = ?0 and pa.AccessType.Name like ?1";
         return (List<ProgramAccess>) this.getHibernateTemplate().find(q, new Object[]{programId, accessType});
     }
 

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramClientRestrictionDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramClientRestrictionDAOImpl.java
@@ -46,7 +46,8 @@ public class ProgramClientRestrictionDAOImpl extends HibernateDaoSupport impleme
 
     public Collection<ProgramClientRestriction> find(int programId, int demographicNo) {
 
-        List<ProgramClientRestriction> pcrs = (List<ProgramClientRestriction>) getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ? and pcr.demographicNo = ? order by pcr.startDate", new Object[]{programId, demographicNo});
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ?0 and pcr.demographicNo = ?1 order by pcr.startDate";
+        List<ProgramClientRestriction> pcrs = (List<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, new Object[]{programId, demographicNo});
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -62,7 +63,8 @@ public class ProgramClientRestrictionDAOImpl extends HibernateDaoSupport impleme
     }
 
     public Collection<ProgramClientRestriction> findForProgram(int programId) {
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ? order by pcr.demographicNo", programId);
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.programId = ?0 order by pcr.demographicNo";
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, programId);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -70,7 +72,8 @@ public class ProgramClientRestrictionDAOImpl extends HibernateDaoSupport impleme
     }
 
     public Collection<ProgramClientRestriction> findDisabledForProgram(int programId) {
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = false and pcr.programId = ? order by pcr.demographicNo", programId);
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = false and pcr.programId = ?0 order by pcr.demographicNo";
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, programId);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -78,7 +81,8 @@ public class ProgramClientRestrictionDAOImpl extends HibernateDaoSupport impleme
     }
 
     public Collection<ProgramClientRestriction> findForClient(int demographicNo) {
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ? order by pcr.programId", demographicNo);
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ?0 order by pcr.programId";
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, demographicNo);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
@@ -86,29 +90,19 @@ public class ProgramClientRestrictionDAOImpl extends HibernateDaoSupport impleme
     }
 
     public Collection<ProgramClientRestriction> findForClient(int demographicNo, int facilityId) {
-        ArrayList<Object> paramList = new ArrayList<Object>();
-        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and " +
-                "pcr.demographicNo = ? and pcr.programId in (select s.id from Program s where s.facilityId = ? or s.facilityId is null) " +
-                "order by pcr.programId";
-        paramList.add(Integer.valueOf(demographicNo));
-        paramList.add(facilityId);
-        Object params[] = paramList.toArray(new Object[paramList.size()]);
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ?0" +
+        " and pcr.programId in (select s.id from Program s where s.facilityId = ?1 or s.facilityId is null) order by pcr.programId";
+        Object params[] = new Object[]{Integer.valueOf(demographicNo), facilityId};
         Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, params);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }
         return pcrs;
-/*
-    	Collection<ProgramClientRestriction> pcrs = getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = true and pcr.demographicNo = ? order by pcr.programId", demographicNo);
-        for (ProgramClientRestriction pcr : pcrs) {
-            setRelationships(pcr);
-        }
-        return pcrs;
-*/
     }
 
     public Collection<ProgramClientRestriction> findDisabledForClient(int demographicNo) {
-        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find("from ProgramClientRestriction pcr where pcr.enabled = false and pcr.demographicNo = ? order by pcr.programId", demographicNo);
+        String sSQL = "from ProgramClientRestriction pcr where pcr.enabled = false and pcr.demographicNo = ?0 order by pcr.programId";
+        Collection<ProgramClientRestriction> pcrs = (Collection<ProgramClientRestriction>) getHibernateTemplate().find(sSQL, demographicNo);
         for (ProgramClientRestriction pcr : pcrs) {
             setRelationships(pcr);
         }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramClientStatusDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramClientStatusDAOImpl.java
@@ -50,7 +50,8 @@ public class ProgramClientStatusDAOImpl extends HibernateDaoSupport implements P
     }
 
     public List<ProgramClientStatus> getProgramClientStatuses(Integer programId) {
-        return (List<ProgramClientStatus>) this.getHibernateTemplate().find("from ProgramClientStatus pcs where pcs.programId=?", programId);
+        String sSQL = "from ProgramClientStatus pcs where pcs.programId=?0";
+        return (List<ProgramClientStatus>) this.getHibernateTemplate().find(sSQL, programId);
     }
 
     public void saveProgramClientStatus(ProgramClientStatus status) {
@@ -85,9 +86,9 @@ public class ProgramClientStatusDAOImpl extends HibernateDaoSupport implements P
         Session session = sessionFactory.getCurrentSession();
         List teams = new ArrayList();
         try {
-            Query query = session.createQuery("select pt.id from ProgramClientStatus pt where pt.programId = ? and pt.name = ?");
-            query.setLong(0, programId.longValue());
-            query.setString(1, statusName);
+            Query query = session.createQuery("select pt.id from ProgramClientStatus pt where pt.programId = ?1 and pt.name = ?2");
+            query.setLong(1, programId.longValue());
+            query.setString(2, statusName);
 
             teams = query.list();
 
@@ -110,7 +111,8 @@ public class ProgramClientStatusDAOImpl extends HibernateDaoSupport implements P
             throw new IllegalArgumentException();
         }
 
-        List<Admission> results = (List<Admission>) this.getHibernateTemplate().find("from Admission a where a.ProgramId = ? and a.TeamId = ? and a.AdmissionStatus='current'", new Object[]{programId, statusId});
+        String sSQL = "from Admission a where a.ProgramId = ?0 and a.TeamId = ?1 and a.AdmissionStatus='current'";
+        List<Admission> results = (List<Admission>) this.getHibernateTemplate().find(sSQL, new Object[]{programId, statusId});
 
         if (log.isDebugEnabled()) {
             log.debug("getAdmissionsInTeam: programId= " + programId + ",statusId=" + statusId + ",# results=" + results.size());

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramDaoImpl.java
@@ -109,7 +109,7 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
             return null;
         }
         Program result = null;
-        String queryStr = "FROM Program p WHERE p.id = ? AND p.exclusiveView = 'appointment'";
+        String queryStr = "FROM Program p WHERE p.id = ?0 AND p.exclusiveView = 'appointment'";
         List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, programId);
 
         if (log.isDebugEnabled()) {
@@ -138,7 +138,7 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
 
         @SuppressWarnings("unchecked")
         List<Program> programs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.name = ? ORDER BY p.id ", programName);
+                .find("FROM Program p WHERE p.name = ?0 ORDER BY p.id ", programName);
         if (!programs.isEmpty()) {
             return programs.get(0).getId();
         } else {
@@ -161,9 +161,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getAllPrograms() {
+        String sSQL = "FROM Program p WHERE p.type != ?0 ORDER BY p.name ";
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.type != ? ORDER BY p.name ", Program.COMMUNITY_TYPE);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(sSQL, Program.COMMUNITY_TYPE);
 
         if (log.isDebugEnabled()) {
             log.debug("getAllPrograms: # of programs: " + rs.size());
@@ -216,10 +216,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getPrograms() {
-        String queryStr = "FROM Program p WHERE p.type != '" + Program.COMMUNITY_TYPE + "' ORDER BY p.name";
-
+        String queryStr = "FROM Program p WHERE p.type != '?0' ORDER BY p.name";
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, Program.COMMUNITY_TYPE);
 
         return rs;
     }
@@ -232,11 +231,10 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getActivePrograms() {
-        String queryStr = "FROM Program p WHERE p.type <> '" + Program.COMMUNITY_TYPE + "' and p.programStatus = '"
-                + Program.PROGRAM_STATUS_ACTIVE + "'";
-
+        String queryStr = "FROM Program p WHERE p.type <> '?0' and p.programStatus = '?1'";
+        Object[] params = new Object[] {Program.COMMUNITY_TYPE, Program.PROGRAM_STATUS_ACTIVE};
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, params);
 
         return rs;
     }
@@ -248,22 +246,20 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getProgramsByFacilityId(Integer facilityId) {
-        String queryStr = "FROM Program p WHERE (p.facilityId = " + facilityId
-                + " or p.facilityId is null) ORDER BY p.name";
+        String queryStr = "FROM Program p WHERE (p.facilityId = ?0 or p.facilityId is null) ORDER BY p.name";
 
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, facilityId);
 
         return rs;
     }
 
     @Override
     public List<Program> getProgramsByFacilityIdAndFunctionalCentreId(Integer facilityId, String functionalCentreId) {
-        String queryStr = "FROM Program p WHERE p.facilityId = " + facilityId + " and p.functionalCentreId = '"
-                + functionalCentreId + '\'';
-
+        String queryStr = "FROM Program p WHERE p.facilityId = ?0 and p.functionalCentreId = '?1'\'";
+        Object[] params = new Object[]{facilityId, functionalCentreId};
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, params);
 
         return rs;
     }
@@ -275,11 +271,11 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
      */
     @Override
     public List<Program> getCommunityProgramsByFacilityId(Integer facilityId) {
-        String queryStr = "FROM Program p WHERE (p.facilityId = " + facilityId
-                + " or p.facilityId is null) AND p.type != '" + Program.COMMUNITY_TYPE + "' ORDER BY p.name";
-
+        String queryStr = "FROM Program p WHERE (p.facilityId = ?0 or p.facilityId is null) " +
+        "AND p.type != '?1' ORDER BY p.name";
+        Object[] params = new Object[]{facilityId, Program.COMMUNITY_TYPE};
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr);
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(queryStr, params);
 
         return rs;
     }
@@ -313,9 +309,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
         // inefficient, but unless I fix all the hibernate calls I'm following
         // convention of
         // using the hibernate templates and just inserting random strings for now.
+        String sSQL = "FROM Program p WHERE p.manOrWoman = '?0'";
         @SuppressWarnings("unchecked")
-        List<Program> rs = (List<Program>) getHibernateTemplate()
-                .find("FROM Program p WHERE p.manOrWoman = '" + genderType + "'");
+        List<Program> rs = (List<Program>) getHibernateTemplate().find(sSQL, genderType);
         return rs;
     }
 
@@ -554,9 +550,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
     public Program getHoldingTankProgram() {
         Program result = null;
 
+        String sSQL = "from Program p where p.holdingTank = true";
         @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate()
-                .find("from Program p where p.holdingTank = true");
+        List<Program> results = (List<Program>) getHibernateTemplate().find(sSQL);
 
         if (!results.isEmpty()) {
             result = results.get(0);
@@ -576,11 +572,11 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
     }
 
     public List<Program> getLinkedServicePrograms(Integer bedProgramId, Integer clientId) {
+        String sSQL = "select p from Admission a,Program p where a.programId = p.id and p.type='?0'" + 
+        " and  p.bedProgramLinkId = ?1 and a.clientId=?2";
+        Object[] params = new Object[]{Program.SERVICE_TYPE, bedProgramId, clientId};
         @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) this.getHibernateTemplate().find(
-                "select p from Admission a,Program p where a.programId = p.id and p.type='" + Program.SERVICE_TYPE
-                        + "' and  p.bedProgramLinkId = ? and a.clientId=?",
-                new Object[]{bedProgramId, clientId});
+        List<Program> results = (List<Program>) this.getHibernateTemplate().find(sSQL, params);
         return results;
     }
 
@@ -607,9 +603,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
     public Program getProgramBySiteSpecificField(String value) {
         Program result = null;
 
+        String sSQL = "from Program p where p.siteSpecificField = ?0";
         @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate()
-                .find("from Program p where p.siteSpecificField = ?", new Object[]{value});
+        List<Program> results = (List<Program>) getHibernateTemplate().find(sSQL, new Object[]{value});
 
         if (!results.isEmpty()) {
             result = results.get(0);
@@ -622,9 +618,9 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
     public Program getProgramByName(String value) {
         Program result = null;
 
+        String sSQL = "from Program p where p.name = ?0";
         @SuppressWarnings("unchecked")
-        List<Program> results = (List<Program>) getHibernateTemplate().find("from Program p where p.name = ?0",
-                new Object[]{value});
+        List<Program> results = (List<Program>) getHibernateTemplate().find(sSQL, new Object[]{value});
 
         if (!results.isEmpty()) {
             result = results.get(0);
@@ -635,28 +631,28 @@ public class ProgramDaoImpl extends HibernateDaoSupport implements ProgramDao {
 
     @Override
     public List<Integer> getRecordsAddedAndUpdatedSinceTime(Integer facilityId, Date date) {
+        String sSQL = "select distinct p.id From Program p where p.facilityId = ?0 and p.lastUpdateDate > ?1  ";
+        Object[] params = new Object[]{facilityId, date};
         @SuppressWarnings("unchecked")
-        List<Integer> programs = (List<Integer>) getHibernateTemplate().find(
-                "select distinct p.id From Program p where p.facilityId = ? and p.lastUpdateDate > ?  ", facilityId,
-                date);
+        List<Integer> programs = (List<Integer>) getHibernateTemplate().find(sSQL, params);
 
         return programs;
     }
 
     @Override
     public List<Integer> getRecordsByFacilityId(Integer facilityId) {
+        String sSQL = "select distinct p.id From Program p where p.facilityId = ?0 ";
         @SuppressWarnings("unchecked")
-        List<Integer> programs = (List<Integer>) getHibernateTemplate()
-                .find("select distinct p.id From Program p where p.facilityId = ? ", facilityId);
+        List<Integer> programs = (List<Integer>) getHibernateTemplate().find(sSQL, facilityId);
 
         return programs;
     }
 
     @Override
     public List<String> getRecordsAddedAndUpdatedSinceTime(Date date) {
+        String sSQL = "select distinct p.ProviderNo From Provider p where p.lastUpdateDate > ?0 ";
         @SuppressWarnings("unchecked")
-        List<String> providers = (List<String>) getHibernateTemplate()
-                .find("select distinct p.ProviderNo From Provider p where p.lastUpdateDate > ? ", date);
+        List<String> providers = (List<String>) getHibernateTemplate().find(sSQL, date);
 
         return providers;
     }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramFunctionalUserDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramFunctionalUserDAOImpl.java
@@ -52,8 +52,8 @@ public class ProgramFunctionalUserDAOImpl extends HibernateDaoSupport implements
 
     @Override
     public List<FunctionalUserType> getFunctionalUserTypes() {
-        List<FunctionalUserType> results = (List<FunctionalUserType>) this.getHibernateTemplate()
-                .find("from FunctionalUserType");
+        String sSQL = "from FunctionalUserType";
+        List<FunctionalUserType> results = (List<FunctionalUserType>) this.getHibernateTemplate().find(sSQL);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUserTypes: # of results=" + results.size());
@@ -108,8 +108,8 @@ public class ProgramFunctionalUserDAOImpl extends HibernateDaoSupport implements
             throw new IllegalArgumentException();
         }
 
-        List<FunctionalUserType> results = (List<FunctionalUserType>) this.getHibernateTemplate()
-                .find("from ProgramFunctionalUser pfu where pfu.ProgramId = ?", programId);
+        String sSQL = "from ProgramFunctionalUser pfu where pfu.ProgramId = ?0";
+        List<FunctionalUserType> results = (List<FunctionalUserType>) this.getHibernateTemplate().find(sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getFunctionalUsers: programId=" + programId + ",# of results=" + results.size());
@@ -169,12 +169,11 @@ public class ProgramFunctionalUserDAOImpl extends HibernateDaoSupport implements
 
         Long result = null;
 
-        // Session session = getSession();
+        String query = "select pfu.ProgramId from ProgramFunctionalUser pfu where pfu.ProgramId = ?0 and pfu.UserTypeId = ?1";
         Session session = sessionFactory.getCurrentSession();
-        Query q = session.createQuery(
-                "select pfu.ProgramId from ProgramFunctionalUser pfu where pfu.ProgramId = ? and pfu.UserTypeId = ?");
-        q.setLong(0, programId.longValue());
-        q.setLong(1, userTypeId.longValue());
+        Query q = session.createQuery();
+        q.setLong(1, programId.longValue());
+        q.setLong(2, userTypeId.longValue());
         List results = new ArrayList();
         try {
             results = q.list();

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramProviderDAOImpl.java
@@ -58,7 +58,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
         List<ProgramProvider> results = programProviderByProviderProgramIdCache.get(cacheKey);
 
         if (results == null) {
-            String q = "select pp from ProgramProvider pp where pp.ProgramId=? and pp.ProviderNo=?";
+            String q = "select pp from ProgramProvider pp where pp.ProgramId=?0 and pp.ProviderNo=?1";
             results = (List<ProgramProvider>) getHibernateTemplate().find(q, new Object[]{programId, providerNo});
             if (results != null)
                 programProviderByProviderProgramIdCache.put(cacheKey, results);
@@ -76,7 +76,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
     @SuppressWarnings("unchecked")
     @Override
     public List<ProgramProvider> getProgramProviderByProviderNo(String providerNo) {
-        String q = "select pp from ProgramProvider pp where pp.ProviderNo=?";
+        String q = "select pp from ProgramProvider pp where pp.ProviderNo=?0";
         return (List<ProgramProvider>) getHibernateTemplate().find(q, providerNo);
     }
 
@@ -88,7 +88,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
 
         @SuppressWarnings("unchecked")
         List<ProgramProvider> results = (List<ProgramProvider>) this.getHibernateTemplate()
-                .find("from ProgramProvider pp where pp.ProgramId = ?", programId);
+                .find("from ProgramProvider pp where pp.ProgramId = ?0", programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProviders: programId=" + programId + ",# of results=" + results.size());
@@ -102,8 +102,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        List<ProgramProvider> results = (List<ProgramProvider>) this.getHibernateTemplate()
-                .find("from ProgramProvider pp where pp.ProviderNo = ?", providerNo);
+        String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?0";
+        List<ProgramProvider> results = (List<ProgramProvider>) this.getHibernateTemplate().find(sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvidersByProvider: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -117,8 +117,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ? and pp.ProgramId in " +
-                "(select s.id from Program s where s.facilityId=? or s.facilityId is null)";
+        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ?0 and pp.ProgramId in " +
+                "(select s.id from Program s where s.facilityId=?1 or s.facilityId is null)";
         List results = getHibernateTemplate().find(queryStr, new Object[]{providerNo, facilityId});
 
         if (log.isDebugEnabled()) {
@@ -153,9 +153,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
         }
 
         ProgramProvider result = null;
-        List results = this.getHibernateTemplate().find(
-                "from ProgramProvider pp where pp.ProviderNo = ? and pp.ProgramId = ?",
-                new Object[]{providerNo, programId});
+        String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?0 and pp.ProgramId = ?1";
+        List results = this.getHibernateTemplate().find(sSQL, new Object[]{providerNo, programId});
         if (!results.isEmpty()) {
             result = (ProgramProvider) results.get(0);
         }
@@ -173,10 +172,9 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
 
         ProgramProvider result = null;
 
+        String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?0 and pp.ProgramId = ?1 and pp.RoleId=?2";
         @SuppressWarnings("unchecked")
-        List<ProgramProvider> results = (List<ProgramProvider>) getHibernateTemplate().find(
-                "from ProgramProvider pp where pp.ProviderNo = ? and pp.ProgramId = ? and pp.RoleId=?",
-                new Object[]{providerNo, programId, roleId});
+        List<ProgramProvider> results = (List<ProgramProvider>) getHibernateTemplate().find(sSQL, new Object[]{providerNo, programId, roleId});
 
         if (!results.isEmpty()) {
             result = results.get(0);
@@ -249,9 +247,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
         }
         Long pId = programId.longValue();
 
-        List<ProgramProvider> results = (List<ProgramProvider>) this.getHibernateTemplate().find(
-                "select pp from ProgramProvider pp left join pp.teams as team where pp.ProgramId = ? and team.id = ?",
-                new Object[]{pId, teamId});
+        String sSQL = "select pp from ProgramProvider pp left join pp.teams as team where pp.ProgramId = ?0 and team.id = ?1";
+        List<ProgramProvider> results = (List<ProgramProvider>) this.getHibernateTemplate().find(sSQL, new Object[]{pId, teamId});
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramProvidersInTeam: programId=" + programId + ",teamId=" + teamId + ",# of results="
@@ -268,7 +265,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        List results = this.getHibernateTemplate().find("from ProgramProvider pp where pp.ProviderNo = ?", providerNo);
+        String sSQL = "from ProgramProvider pp where pp.ProviderNo = ?0";
+        List results = this.getHibernateTemplate().find(sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramDomain: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -282,9 +280,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        List results = this.getHibernateTemplate().find(
-                "select pp from ProgramProvider pp, Program p where pp.ProgramId=p.id and p.programStatus='active' and pp.ProviderNo = ?",
-                providerNo);
+        String sSQL = "select pp from ProgramProvider pp, Program p where pp.ProgramId=p.id and p.programStatus='active' and pp.ProviderNo = ?0";
+        List results = this.getHibernateTemplate().find(sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramDomain: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -298,8 +295,8 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ? and pp.ProgramId in " +
-                "(select s.id from Program s where s.facilityId=? or s.facilityId is null)";
+        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ?0 and pp.ProgramId in " +
+                "(select s.id from Program s where s.facilityId=?1 or s.facilityId is null)";
         List results = getHibernateTemplate().find(queryStr, new Object[]{providerNo, facilityId});
 
         if (log.isDebugEnabled()) {
@@ -314,7 +311,7 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
             throw new IllegalArgumentException();
         }
 
-        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ? and pp.ProgramId = ?";
+        String queryStr = "from ProgramProvider pp where pp.ProviderNo = ?0 and pp.ProgramId = ?1";
         List results = getHibernateTemplate().find(queryStr,
                 new Object[]{providerNo, Long.valueOf(programId.longValue())});
         if (results != null && results.size() > 0) {
@@ -331,9 +328,9 @@ public class ProgramProviderDAOImpl extends HibernateDaoSupport implements Progr
         if (providerNo == null || Long.valueOf(providerNo) == null) {
             throw new IllegalArgumentException();
         }
-        List results = this.getHibernateTemplate().find(
-                "select distinct f from Facility f, Room r, ProgramProvider pp where pp.ProgramId = r.programId and f.id = r.facilityId and pp.ProviderNo = ?",
-                providerNo);
+        String sSQL = "select distinct f from Facility f, Room r, ProgramProvider pp " +
+        "where pp.ProgramId = r.programId and f.id = r.facilityId and pp.ProviderNo = ?0";
+        List results = this.getHibernateTemplate().find(sSQL, providerNo);
 
         return results;
     }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramQueueDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramQueueDaoImpl.java
@@ -59,7 +59,7 @@ public class ProgramQueueDaoImpl extends HibernateDaoSupport implements ProgramQ
             throw new IllegalArgumentException();
         }
 
-        String queryStr = " FROM ProgramQueue q WHERE q.ProgramId=? ORDER BY  q.Id  ";
+        String queryStr = " FROM ProgramQueue q WHERE q.ProgramId=?0 ORDER BY  q.Id  ";
         List results = getHibernateTemplate().find(queryStr, programId);
 
         if (log.isDebugEnabled()) {
@@ -76,7 +76,7 @@ public class ProgramQueueDaoImpl extends HibernateDaoSupport implements ProgramQ
         }
 
         List results = this.getHibernateTemplate().find(
-                "from ProgramQueue pq where pq.ProgramId = ? and pq.Status = 'active' order by pq.ReferralDate",
+                "from ProgramQueue pq where pq.ProgramId = ?0 and pq.Status = 'active' order by pq.ReferralDate",
                 Long.valueOf(programId));
 
         if (log.isDebugEnabled()) {
@@ -110,9 +110,9 @@ public class ProgramQueueDaoImpl extends HibernateDaoSupport implements ProgramQ
         }
 
         ProgramQueue result = null;
-        List results = this.getHibernateTemplate().find(
-                "from ProgramQueue pq where pq.ProgramId = ? and pq.ClientId = ?",
-                new Object[]{Long.valueOf(programId), Long.valueOf(clientId)});
+        String sSQL = "from ProgramQueue pq where pq.ProgramId = ?0 and pq.ClientId = ?1";
+        Object[] params = new Object[]{Long.valueOf(programId), Long.valueOf(clientId)};
+        List results = this.getHibernateTemplate().find(sSQL,params);
 
         if (!results.isEmpty()) {
             result = (ProgramQueue) results.get(0);
@@ -136,9 +136,9 @@ public class ProgramQueueDaoImpl extends HibernateDaoSupport implements ProgramQ
 
         ProgramQueue result = null;
 
-        List results = this.getHibernateTemplate().find(
-                "from ProgramQueue pq where pq.ProgramId = ? and pq.ClientId = ? and pq.Status='active'",
-                new Object[]{programId, demographicNo});
+        String sSQL = "from ProgramQueue pq where pq.ProgramId = ?0 and pq.ClientId = ?1 and pq.Status='active'";
+        Object[] params = new Object[]{programId, demographicNo};
+        List results = this.getHibernateTemplate().find(sSQL, params);
         if (!results.isEmpty()) {
             result = (ProgramQueue) results.get(0);
         }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramSignatureDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramSignatureDaoImpl.java
@@ -45,7 +45,8 @@ public class ProgramSignatureDaoImpl extends HibernateDaoSupport implements Prog
         if (programId == null || programId.intValue() <= 0) {
             return null;
         }
-        List ps = getHibernateTemplate().find("FROM ProgramSignature ps where ps.programId = ? ORDER BY ps.updateDate ASC", programId);
+        String sSQL = "FROM ProgramSignature ps where ps.programId = ?0 ORDER BY ps.updateDate ASC";
+        List ps = getHibernateTemplate().find(sSQL, programId);
 
         if (!ps.isEmpty()) {
             programSignature = (ProgramSignature) ps.get(0);
@@ -63,7 +64,8 @@ public class ProgramSignatureDaoImpl extends HibernateDaoSupport implements Prog
             return null;
         }
 
-        List rs = getHibernateTemplate().find("FROM ProgramSignature ps WHERE ps.programId = ? ORDER BY ps.updateDate ASC", programId);
+        String sSQL = "FROM ProgramSignature ps WHERE ps.programId = ?0 ORDER BY ps.updateDate ASC";
+        List rs = getHibernateTemplate().find(sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramSignatures: # of programs: " + rs.size());

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramTeamDAOImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramTeamDAOImpl.java
@@ -78,7 +78,7 @@ public class ProgramTeamDAOImpl extends HibernateDaoSupport implements ProgramTe
         }
         // Session session = getSession();
         Session session = sessionFactory.getCurrentSession();
-        Query query = session.createQuery("select pt.id from ProgramTeam pt where pt.programId = ? and pt.name = ?");
+        Query query = session.createQuery("select pt.id from ProgramTeam pt where pt.programId = ? and pt.name = ?" );
         query.setLong(0, programId.longValue());
         query.setString(1, teamName);
 
@@ -128,7 +128,8 @@ public class ProgramTeamDAOImpl extends HibernateDaoSupport implements ProgramTe
             throw new IllegalArgumentException();
         }
 
-        List<ProgramTeam> results = (List<ProgramTeam>) this.getHibernateTemplate().find("from ProgramTeam tp where tp.programId = ?", programId);
+        String sSQL = "from ProgramTeam tp where tp.programId = ?0";
+        List<ProgramTeam> results = (List<ProgramTeam>) this.getHibernateTemplate().find(sSQL, programId);
 
         if (log.isDebugEnabled()) {
             log.debug("getProgramTeams: programId=" + programId + ",# of results=" + results.size());

--- a/src/main/java/org/oscarehr/PMmodule/dao/SecUserRoleDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/SecUserRoleDaoImpl.java
@@ -47,9 +47,9 @@ public class SecUserRoleDaoImpl extends HibernateDaoSupport implements SecUserRo
             throw new IllegalArgumentException();
         }
 
+        String sSQL = "from SecUserRole s where s.ProviderNo = ?0";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate()
-                .find("from SecUserRole s where s.ProviderNo = ?", providerNo);
+        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate().find(sSQL, providerNo);
 
         if (log.isDebugEnabled()) {
             log.debug("getUserRoles: providerNo=" + providerNo + ",# of results=" + results.size());
@@ -60,18 +60,18 @@ public class SecUserRoleDaoImpl extends HibernateDaoSupport implements SecUserRo
 
     @Override
     public List<SecUserRole> getSecUserRolesByRoleName(String roleName) {
+        String sSQL = "from SecUserRole s where s.RoleName = ?0";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate()
-                .find("from SecUserRole s where s.RoleName = ?", roleName);
+        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate().find(sSQL, roleName);
 
         return results;
     }
 
     @Override
     public List<SecUserRole> findByRoleNameAndProviderNo(String roleName, String providerNo) {
+        String sSQL = "from SecUserRole s where s.RoleName = ?0 and s.ProviderNo=?1";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate().find(
-                "from SecUserRole s where s.RoleName = ? and s.ProviderNo=?", new Object[]{roleName, providerNo});
+        List<SecUserRole> results = (List<SecUserRole>) getHibernateTemplate().find(sSQL, new Object[]{roleName, providerNo});
 
         return results;
     }
@@ -83,9 +83,9 @@ public class SecUserRoleDaoImpl extends HibernateDaoSupport implements SecUserRo
         }
 
         boolean result = false;
+        String sSQL = "from SecUserRole s where s.ProviderNo = ?0 and s.RoleName = 'admin'";
         @SuppressWarnings("unchecked")
-        List<SecUserRole> results = (List<SecUserRole>) this.getHibernateTemplate()
-                .find("from SecUserRole s where s.ProviderNo = ? and s.RoleName = 'admin'", providerNo);
+        List<SecUserRole> results = (List<SecUserRole>) this.getHibernateTemplate().find(sSQL, providerNo);
         if (!results.isEmpty()) {
             result = true;
         }
@@ -110,9 +110,9 @@ public class SecUserRoleDaoImpl extends HibernateDaoSupport implements SecUserRo
 
     @Override
     public List<String> getRecordsAddedAndUpdatedSinceTime(Date date) {
+        String sSQL = "select p.ProviderNo From SecUserRole p WHERE p.lastUpdateDate > ?0";
         @SuppressWarnings("unchecked")
-        List<String> records = (List<String>) getHibernateTemplate()
-                .find("select p.ProviderNo From SecUserRole p WHERE p.lastUpdateDate > ?", date);
+        List<String> records = (List<String>) getHibernateTemplate().find(sSQL, date);
 
         return records;
     }


### PR DESCRIPTION
## Changes made
- Updated Hibernate queries in `DaoImpl` files in the `org/oscarehr/PMmodule` directory to start from 0.
  - If setParameter was used, the parameters start from 1.
- Reformatted query strings to be more readable.

## Summary by Sourcery

Refactor Hibernate queries in the PMmodule to use named parameters starting from 0 and reformat query strings for better readability. Update dependencies in the project to newer versions.

Enhancements:
- Refactor Hibernate queries in multiple DAO implementation files to use named parameters starting from 0 for improved readability and consistency.
- Reformat query strings across various DAO classes to enhance readability and maintainability.

Build:
- Update dependencies in the dependencies-lock.json file, including upgrades to versions of several libraries such as Hibernate, Classmate, and others.