### PR TITLE
Fix table names in JPA queries

### DIFF
--- a/src/main/java/org/oscarehr/common/dao/EFormDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/EFormDaoImpl.java
@@ -73,9 +73,8 @@ public class EFormDaoImpl extends AbstractDaoImpl<EForm> implements EFormDao {
 
     @Override
     public EForm findById(Integer formId) {
-        Query query = entityManager.createQuery("select x from ?1 x where x.id=?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, formId);
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x where x.id=?1");
+        query.setParameter(1, formId);
 
         return this.getSingleResultOrNull(query);
     }
@@ -167,12 +166,11 @@ public class EFormDaoImpl extends AbstractDaoImpl<EForm> implements EFormDao {
     @SuppressWarnings("unchecked")
     @Override
     public List<EForm> findByStatus(boolean status, EFormSortOrder sortOrder) {
-        StringBuilder buf = new StringBuilder("FROM ?1 ef WHERE ef.current = ?2");
+        StringBuilder buf = new StringBuilder("FROM " + modelClass.getSimpleName() + " ef WHERE ef.current = ?1");
         buf.append(getSortOrderClause(sortOrder));
 
         Query query = entityManager.createQuery(buf.toString());
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, status);
+        query.setParameter(1, status);
 
         return query.getResultList();
     }
@@ -204,9 +202,8 @@ public class EFormDaoImpl extends AbstractDaoImpl<EForm> implements EFormDao {
      */
     @Override
     public Integer findMaxIdForActiveForm(String formName) {
-        Query query = entityManager.createQuery("SELECT MAX(ef.id) FROM ?1 ef WHERE ef.formName = ?2 AND ef.current = TRUE");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, formName);
+        Query query = entityManager.createQuery("SELECT MAX(ef.id) FROM " + modelClass.getSimpleName() + " ef WHERE ef.formName = ?1 AND ef.current = TRUE");
+        query.setParameter(1, formName);
         return (Integer) query.getSingleResult();
     }
 
@@ -221,10 +218,9 @@ public class EFormDaoImpl extends AbstractDaoImpl<EForm> implements EFormDao {
     @Override
     public Long countFormsOtherThanSpecified(String formName, Integer id) {
         // TODO test me
-        Query query = entityManager.createQuery("SELECT COUNT(ef) FROM ?1 ef WHERE ef.current = TRUE AND ef.formName = ?2 AND ef.id != ?3");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, formName);
-        query.setParameter(3, id);
+        Query query = entityManager.createQuery("SELECT COUNT(ef) FROM " + modelClass.getSimpleName() + " ef WHERE ef.current = TRUE AND ef.formName = ?1 AND ef.id != ?2");
+        query.setParameter(1, formName);
+        query.setParameter(2, id);
         return (Long) query.getSingleResult();
     }
 

--- a/src/main/java/org/oscarehr/common/dao/OscarJobDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/OscarJobDaoImpl.java
@@ -52,9 +52,8 @@ public class OscarJobDaoImpl extends AbstractDaoImpl<OscarJob> implements OscarJ
 
     @Override
     public List<OscarJob> getJobByName(String name) {
-        Query query = entityManager.createQuery("select x from ?1 x where x.name = ?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, name);
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x where x.name = ?1");
+        query.setParameter(1, name);
         return query.getResultList();
     }
 }

--- a/src/main/java/org/oscarehr/common/dao/OscarLogDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/OscarLogDaoImpl.java
@@ -49,11 +49,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<OscarLog> findByDemographicId(Integer demographicId) {
 
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
+        query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
         List<OscarLog> results = query.getResultList();
@@ -64,11 +63,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<OscarLog> findByProviderNo(String providerNo) {
 
-        String sqlCommand = "select x from ?1 x where x.providerNo=?2 order by x.created";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.providerNo=?1 order by x.created";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, providerNo);
+        query.setParameter(1, providerNo);
 
         @SuppressWarnings("unchecked")
         List<OscarLog> results = query.getResultList();
@@ -78,12 +76,11 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
 
     @Override
     public boolean hasRead(String providerNo, String content, String contentId) {
-        String sqlCommand = "select x from ?1 x where x.action = 'read' and  x.providerNo=?2 and x.content = ?3 and x.contentId = ?4";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.action = 'read' and  x.providerNo=?1 and x.content = ?2 and x.contentId = ?3";
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, providerNo);
-        query.setParameter(3, content);
-        query.setParameter(4, contentId);
+        query.setParameter(1, providerNo);
+        query.setParameter(2, content);
+        query.setParameter(3, contentId);
 
         @SuppressWarnings("unchecked")
         List<OscarLog> results = query.getResultList();
@@ -96,11 +93,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
 
     @Override
     public List<OscarLog> findByActionAndData(String action, String data) {
-        String sqlCommand = "select x from ?1 x where x.action = ?2 and x.data = ?3 order by x.created DESC";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.action = ?1 and x.data = ?2 order by x.created DESC";
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, action);
-        query.setParameter(3, data);
+        query.setParameter(1, action);
+        query.setParameter(2, data);
 
         @SuppressWarnings("unchecked")
         List<OscarLog> results = query.getResultList();
@@ -120,11 +116,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
             return new ArrayList<OscarLog>();
         }
 
-        String sqlCommand = "select x from ?1 x where x.action = ?2 order by x."
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.action = ?1 order by x."
                 + orderBy + " " + orderByDirection;
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, action);
+        query.setParameter(1, action);
         query.setFirstResult(start);
         query.setMaxResults(length);
 
@@ -137,13 +132,12 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<OscarLog> findByActionContentAndDemographicId(String action, String content, Integer demographicId) {
 
-        String sqlCommand = "select x from ?1 x where x.action=?2 and x.content = ?3 and x.demographicId=?4 order by x.created desc";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.action=?1 and x.content = ?2 and x.demographicId=?3 order by x.created desc";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, action);
-        query.setParameter(3, content);
-        query.setParameter(4, demographicId);
+        query.setParameter(1, action);
+        query.setParameter(2, content);
+        query.setParameter(3, demographicId);
 
         @SuppressWarnings("unchecked")
         List<OscarLog> results = query.getResultList();
@@ -153,11 +147,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
 
     @Override
     public List<Integer> getDemographicIdsOpenedSinceTime(Date value) {
-        String sqlCommand = "select distinct demographicId from ?1 where dateTime >= ?2";
+        String sqlCommand = "select distinct demographicId from " + modelClass.getSimpleName() + " where dateTime >= ?1";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, value);
+        query.setParameter(1, value);
 
         @SuppressWarnings("unchecked")
         List<Integer> results = query.getResultList();
@@ -169,11 +162,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<Integer> getRecentDemographicsAccessedByProvider(String providerNo, int startPosition,
                                                                  int itemsToReturn) {
-        String sqlCommand = "select distinct demographicId from ?1 l where l.providerNo = ?2 and l.demographicId is not null and l.demographicId != '-1' order by dateTime desc";
+        String sqlCommand = "select distinct demographicId from " + modelClass.getSimpleName() + " l where l.providerNo = ?1 and l.demographicId is not null and l.demographicId != '-1' order by dateTime desc";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, providerNo);
+        query.setParameter(1, providerNo);
         query.setFirstResult(startPosition);
         setLimit(query, itemsToReturn);
 
@@ -192,11 +184,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<Object[]> getRecentDemographicsViewedByProvider(String providerNo, int startPosition,
                                                                 int itemsToReturn) {
-        String sqlCommand = "select l.demographicId,MAX(l.created) as dt from ?1 l where l.providerNo = ?2 and l.demographicId is not null and l.demographicId != '-1' group by l.demographicId order by MAX(l.created) desc";
+        String sqlCommand = "select l.demographicId,MAX(l.created) as dt from " + modelClass.getSimpleName() + " l where l.providerNo = ?1 and l.demographicId is not null and l.demographicId != '-1' group by l.demographicId order by MAX(l.created) desc";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, providerNo);
+        query.setParameter(1, providerNo);
         query.setFirstResult(startPosition);
         setLimit(query, itemsToReturn);
 
@@ -215,12 +206,11 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     @Override
     public List<Object[]> getRecentDemographicsViewedByProviderAfterDateIncluded(String providerNo, Date date,
                                                                                  int startPosition, int itemsToReturn) {
-        String sqlCommand = "select l.demographicId,MAX(l.created) as dt from ?1 l where l.providerNo = ?2 and l.created >= ?3 and l.demographicId is not null and l.demographicId != '-1' group by l.demographicId order by MAX(l.created) desc";
+        String sqlCommand = "select l.demographicId,MAX(l.created) as dt from " + modelClass.getSimpleName() + " l where l.providerNo = ?1 and l.created >= ?2 and l.demographicId is not null and l.demographicId != '-1' group by l.demographicId order by MAX(l.created) desc";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, providerNo);
-        query.setParameter(3, date);
+        query.setParameter(1, providerNo);
+        query.setParameter(2, date);
         query.setFirstResult(startPosition);
         setLimit(query, itemsToReturn);
 
@@ -237,11 +227,10 @@ public class OscarLogDaoImpl extends AbstractDaoImpl<OscarLog> implements OscarL
     public int purgeLogEntries(Date maxDateToRemove) {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
-        String sqlCommand = "delete from ?1 WHERE dateTime <= ?2";
+        String sqlCommand = "delete from " + modelClass.getSimpleName() + " WHERE dateTime <= ?1";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, formatter.format(maxDateToRemove));
+        query.setParameter(1, formatter.format(maxDateToRemove));
         int ret = query.executeUpdate();
 
         return ret;

--- a/src/main/java/org/oscarehr/common/dao/PrescriptionDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PrescriptionDaoImpl.java
@@ -45,11 +45,10 @@ public class PrescriptionDaoImpl extends AbstractDaoImpl<Prescription> implement
     @Override
     public List<Prescription> findByDemographicId(Integer demographicId) {
 
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
+        query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
         List<Prescription> results = query.getResultList();
@@ -58,12 +57,11 @@ public class PrescriptionDaoImpl extends AbstractDaoImpl<Prescription> implement
 
     @Override
     public List<Prescription> findByDemographicIdUpdatedAfterDate(Integer demographicId, Date afterThisDate) {
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2 and x.lastUpdateDate>=?3";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1 and x.lastUpdateDate>=?2";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
-        query.setParameter(3, afterThisDate);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, afterThisDate);
 
         @SuppressWarnings("unchecked")
         List<Prescription> results = query.getResultList();
@@ -72,12 +70,11 @@ public class PrescriptionDaoImpl extends AbstractDaoImpl<Prescription> implement
 
     @Override
     public List<Prescription> findByDemographicIdUpdatedAfterDateExclusive(Integer demographicId, Date afterThisDate) {
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2 and x.lastUpdateDate>?3";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1 and x.lastUpdateDate>?2";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
-        query.setParameter(3, afterThisDate);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, afterThisDate);
 
         @SuppressWarnings("unchecked")
         List<Prescription> results = query.getResultList();
@@ -115,13 +112,12 @@ public class PrescriptionDaoImpl extends AbstractDaoImpl<Prescription> implement
     @Override
     public List<Prescription> findByProviderDemographicLastUpdateDate(String providerNo, Integer demographicId,
                                                                       Date updatedAfterThisDateExclusive, int itemsToReturn) {
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2 and x.providerNo=?3 and x.lastUpdateDate>?4 order by x.lastUpdateDate";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1 and x.providerNo=?2 and x.lastUpdateDate>?3 order by x.lastUpdateDate";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
-        query.setParameter(3, providerNo);
-        query.setParameter(4, updatedAfterThisDateExclusive);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, providerNo);
+        query.setParameter(3, updatedAfterThisDateExclusive);
         setLimit(query, itemsToReturn);
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/org/oscarehr/common/dao/PreventionDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PreventionDaoImpl.java
@@ -42,9 +42,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByDemographicId(Integer demographicId) {
-        Query query = entityManager.createQuery("select x from ?1 x where demographicId=?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, demographicId);
 
         List<Prevention> results = query.getResultList();
 
@@ -56,11 +56,10 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
      */
     @Override
     public List<Prevention> findByUpdateDate(Date updatedAfterThisDateExclusive, int itemsToReturn) {
-        String sqlCommand = "select x from ?1 x where x.lastUpdateDate>?2 order by x.lastUpdateDate";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.lastUpdateDate>?1 order by x.lastUpdateDate";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, updatedAfterThisDateExclusive);
+        query.setParameter(1, updatedAfterThisDateExclusive);
         setLimit(query, itemsToReturn);
 
         @SuppressWarnings("unchecked")
@@ -70,7 +69,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByDemographicIdAfterDatetime(Integer demographicId, Date dateTime) {
-        Query query = entityManager.createQuery("select x from Prevention x where demographicId=?1 and lastUpdateDate>=?2 and deleted='0'");
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1 and lastUpdateDate>=?2 and deleted='0'";
+
+        Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, demographicId);
         query.setParameter(2, dateTime);
 
@@ -82,7 +83,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByDemographicIdAfterDatetimeExclusive(Integer demographicId, Date dateTime) {
-        Query query = entityManager.createQuery("select x from Prevention x where demographicId=?1 and lastUpdateDate>?2 and deleted='0'");
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1 and lastUpdateDate>?2 and deleted='0'";
+
+        Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, demographicId);
         query.setParameter(2, dateTime);
 
@@ -97,7 +100,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
      */
     @Override
     public List<Integer> findDemographicIdsAfterDatetime(Date dateTime) {
-        Query query = entityManager.createQuery("select x.demographicId from Prevention x where x.lastUpdateDate > ?1");
+        String sqlCommand = "select x.demographicId from " + modelClass.getSimpleName() + " x where x.lastUpdateDate > ?1";
+
+        Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, dateTime);
 
         @SuppressWarnings("unchecked")
@@ -108,13 +113,12 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByProviderDemographicLastUpdateDate(String providerNo, Integer demographicId, Date updatedAfterThisDateExclusive, int itemsToReturn) {
-        String sqlCommand = "select x from ?1 x where x.demographicId=?2 and x.providerNo=?3 and x.lastUpdateDate>?4 order by x.lastUpdateDate";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.demographicId=?1 and x.providerNo=?2 and x.lastUpdateDate>?3 order by x.lastUpdateDate";
 
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
-        query.setParameter(3, providerNo);
-        query.setParameter(4, updatedAfterThisDateExclusive);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, providerNo);
+        query.setParameter(3, updatedAfterThisDateExclusive);
         setLimit(query, itemsToReturn);
 
         @SuppressWarnings("unchecked")
@@ -124,7 +128,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findNotDeletedByDemographicIdAfterDatetime(Integer demographicId, Date dateTime) {
-        Query query = entityManager.createQuery("select x from Prevention x where demographicId=?1 and lastUpdateDate> ?2");
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1 and lastUpdateDate> ?2";
+
+        Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, demographicId);
         query.setParameter(2, dateTime);
 
@@ -136,7 +142,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Integer> findNonDeletedIdsByDemographic(Integer demographicId) {
-        Query query = entityManager.createQuery("select x.id from Prevention x where demographicId=?1 and deleted='0'");
+        String sqlCommand = "select x.id from " + modelClass.getSimpleName() + " x where demographicId=?1 and deleted='0'";
+
+        Query query = entityManager.createQuery(sqlCommand);
         query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
@@ -147,10 +155,11 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findNotDeletedByDemographicId(Integer demographicId) {
-        Query query = entityManager.createQuery("select x from ?1 x where demographicId=?2 and deleted=?3");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
-        query.setParameter(3, '0');
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1 and deleted=?2";
+
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, demographicId);
+        query.setParameter(2, '0');
 
         @SuppressWarnings("unchecked")
         List<Prevention> results = query.getResultList();
@@ -160,11 +169,12 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByTypeAndDate(String preventionType, Date startDate, Date endDate) {
-        Query query = entityManager.createQuery("select x from ?1 x where preventionType=?2 and preventionDate>=?3 and preventionDate<=?4 and deleted='0' and refused='0' order by preventionDate");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, preventionType);
-        query.setParameter(3, startDate);
-        query.setParameter(4, endDate);
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and preventionDate>=?2 and preventionDate<=?3 and deleted='0' and refused='0' order by preventionDate";
+
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, preventionType);
+        query.setParameter(2, startDate);
+        query.setParameter(3, endDate);
 
         @SuppressWarnings("unchecked")
         List<Prevention> results = query.getResultList();
@@ -174,10 +184,11 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findByTypeAndDemoNo(String preventionType, Integer demoNo) {
-        Query query = entityManager.createQuery("select x from ?1 x where preventionType=?2 and demographicId=?3 and deleted='0' order by preventionDate");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, preventionType);
-        query.setParameter(3, demoNo);
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where preventionType=?1 and demographicId=?2 and deleted='0' order by preventionDate";
+
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, preventionType);
+        query.setParameter(2, demoNo);
 
         @SuppressWarnings("unchecked")
         List<Prevention> results = query.getResultList();
@@ -194,9 +205,9 @@ public class PreventionDaoImpl extends AbstractDaoImpl<Prevention> implements Pr
 
     @Override
     public List<Prevention> findUniqueByDemographicId(Integer demographicId) {
-        Query query = entityManager.createQuery("select x from ?1 x where demographicId=?2 and deleted='0' GROUP BY preventionType ORDER BY preventionDate DESC");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicId);
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where demographicId=?1 and deleted='0' GROUP BY preventionType ORDER BY preventionDate DESC";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, demographicId);
 
         @SuppressWarnings("unchecked")
         List<Prevention> results = query.getResultList();

--- a/src/main/java/org/oscarehr/common/dao/PreventionReportDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PreventionReportDaoImpl.java
@@ -43,9 +43,8 @@ public class PreventionReportDaoImpl extends AbstractDaoImpl<PreventionReport> i
 
     @Override
     public List<PreventionReport> getPreventionReports() {
-        String sql = "select x from ?1 x where x.active = true order by x.createDate desc";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.active = true order by x.createDate desc";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(1, modelClass.getSimpleName());
 
         @SuppressWarnings("unchecked")
         List<PreventionReport> allergies = query.getResultList();

--- a/src/main/java/org/oscarehr/common/dao/PrintResourceLogDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PrintResourceLogDaoImpl.java
@@ -42,10 +42,9 @@ public class PrintResourceLogDaoImpl extends AbstractDaoImpl<PrintResourceLog> i
 
     @Override
     public List<PrintResourceLog> findByResource(String resourceName, String resourceId) {
-        Query query = entityManager.createQuery("select x from ?1 x WHERE x.resourceName=?2 and x.resourceId = ?3 order by x.dateTime DESC");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, resourceName);
-        query.setParameter(3, resourceId);
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x WHERE x.resourceName=?1 and x.resourceId = ?2 order by x.dateTime DESC");
+        query.setParameter(1, resourceName);
+        query.setParameter(2, resourceId);
 
         @SuppressWarnings("unchecked")
         List<PrintResourceLog> results = query.getResultList();

--- a/src/main/java/org/oscarehr/common/dao/ProfessionalSpecialistDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ProfessionalSpecialistDaoImpl.java
@@ -47,8 +47,7 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findAll() {
-        Query query = entityManager.createQuery("select x from ?1 x order by x.lastName,x.firstName");
-        query.setParameter(1, modelClass.getSimpleName());
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x order by x.lastName,x.firstName");
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> results = query.getResultList();
@@ -61,8 +60,7 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
      */
     @Override
     public List<ProfessionalSpecialist> findByEDataUrlNotNull() {
-        Query query = entityManager.createQuery("select x from ?1 x where x.eDataUrl is not null order by x.lastName,x.firstName");
-        query.setParameter(1, modelClass.getSimpleName());
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x where x.eDataUrl is not null order by x.lastName,x.firstName");
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> results = query.getResultList();
@@ -72,10 +70,9 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findByFullName(String lastName, String firstName) {
-        Query query = entityManager.createQuery("select x from ?1 x WHERE x.lastName like ?2 and x.firstName like ?3 order by x.lastName");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, "%" + lastName + "%");
-        query.setParameter(3, "%" + firstName + "%");
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x WHERE x.lastName like ?1 and x.firstName like ?2 order by x.lastName");
+        query.setParameter(1, "%" + lastName + "%");
+        query.setParameter(2, "%" + firstName + "%");
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> cList = query.getResultList();
@@ -94,9 +91,8 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findBySpecialty(String specialty) {
-        Query query = entityManager.createQuery("select x from ?1 x WHERE x.specialtyType like ?2 order by x.lastName");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, "%" + specialty + "%");
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x WHERE x.specialtyType like ?1 order by x.lastName");
+        query.setParameter(1, "%" + specialty + "%");
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> cList = query.getResultList();
@@ -117,8 +113,7 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
         // referral numbers often have zeros prepended and are stored as varchar.
         Query query = entityManager.createQuery("select x from ?1 x WHERE x.referralNo LIKE ?2 order by x.lastName");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, referralNo);
+        query.setParameter(1, referralNo);
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> cList = query.getResultList();
@@ -181,8 +176,8 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findByFullNameAndSpecialtyAndAddress(String lastName, String firstName, String specialty, String address, Boolean showHidden) {
-        String sql = "select x from ?1 x WHERE (x.lastName like ?2 and x.firstName like ?3) ";
-        int paramIndex = 4;
+        String sql = "select x from " + modelClass.getSimpleName() + " x WHERE (x.lastName like ?1 and x.firstName like ?2) ";
+        int paramIndex = 3;
         if (!StringUtils.isEmpty(specialty)) {
             sql += " AND x.specialtyType LIKE ?" + paramIndex++ + " ";
         }
@@ -197,9 +192,8 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
         sql += " order by x.lastName";
 
         Query query = entityManager.createQuery(sql);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, "%" + lastName + "%");
-        query.setParameter(3, "%" + firstName + "%");
+        query.setParameter(1, "%" + lastName + "%");
+        query.setParameter(2, "%" + firstName + "%");
 
         paramIndex = 4;
         if (!StringUtils.isEmpty(specialty)) {
@@ -217,9 +211,8 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findByService(String serviceName) {
-        Query query = entityManager.createQuery("select x from ?1 x, ConsultationServices cs, ServiceSpecialists ss WHERE x.id = ss.id.specId and ss.id.serviceId = cs.serviceId and cs.serviceDesc = ?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, serviceName);
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x, ConsultationServices cs, ServiceSpecialists ss WHERE x.id = ss.id.specId and ss.id.serviceId = cs.serviceId and cs.serviceDesc = ?1");
+        query.setParameter(1, serviceName);
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> cList = query.getResultList();
@@ -230,9 +223,8 @@ public class ProfessionalSpecialistDaoImpl extends AbstractDaoImpl<ProfessionalS
 
     @Override
     public List<ProfessionalSpecialist> findByServiceId(Integer serviceId) {
-        Query query = entityManager.createQuery("select x from ?1 x, ServiceSpecialists ss WHERE x.id = ss.id.specId and ss.id.serviceId = ?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, serviceId);
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x, ServiceSpecialists ss WHERE x.id = ss.id.specId and ss.id.serviceId = ?1");
+        query.setParameter(1, serviceId);
 
         @SuppressWarnings("unchecked")
         List<ProfessionalSpecialist> cList = query.getResultList();

--- a/src/main/java/org/oscarehr/common/dao/ProgramAccessRolesDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ProgramAccessRolesDaoImpl.java
@@ -46,8 +46,7 @@ public class ProgramAccessRolesDaoImpl extends AbstractDaoImpl<ProgramAccessRole
      */
     @Override
     public int removeAll() {
-        Query q = entityManager.createQuery("DELETE FROM ?1");
-        q.setParameter(1, modelClass.getSimpleName());
+        Query q = entityManager.createQuery("DELETE FROM " + modelClass.getSimpleName());
         return q.executeUpdate();
     }
 }

--- a/src/main/java/org/oscarehr/common/dao/PropertyDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PropertyDaoImpl.java
@@ -51,9 +51,9 @@ public class PropertyDaoImpl extends AbstractDaoImpl<Property> implements Proper
      */
     @Override
     public List<Property> findByName(String name) {
-        String sqlCommand = "select x from ?1 x where x.name=?2";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.name=?2";
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
+        //query.setParameter(1, );
         query.setParameter(2, name);
         return query.getResultList();
     }
@@ -67,10 +67,9 @@ public class PropertyDaoImpl extends AbstractDaoImpl<Property> implements Proper
      */
     @Override
     public List<Property> findGlobalByName(String name) {
-        String sqlCommand = "select x from ?1 x where x.name=?2 and x.providerNo is null";
+        String sqlCommand = "select x from " + modelClass.getSimpleName() + " x where x.name=?1 and x.providerNo is null";
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, name);
+        query.setParameter(1, name);
         return query.getResultList();
     }
 
@@ -100,10 +99,9 @@ public class PropertyDaoImpl extends AbstractDaoImpl<Property> implements Proper
     @Override
     public Property checkByName(String name) {
 
-        String sql = " select x from ?1 x where x.name=?2";
+        String sql = " select x from " + modelClass.getSimpleName() + " x where x.name=?1";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(1, this.modelClass.getSimpleName());
-        query.setParameter(2, name);
+        query.setParameter(1, name);
 
         try {
             return (Property) query.getSingleResult();
@@ -134,10 +132,9 @@ public class PropertyDaoImpl extends AbstractDaoImpl<Property> implements Proper
 
     @Override
     public void removeByName(String name) {
-        String sqlCommand = "delete from ?1 where name=?2";
+        String sqlCommand = "delete from " + modelClass.getSimpleName() + " where name=?1";
         Query query = entityManager.createQuery(sqlCommand);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, name);
+        query.setParameter(1, name);
         query.executeUpdate();
     }
 

--- a/src/main/java/org/oscarehr/common/dao/PublicKeyDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PublicKeyDaoImpl.java
@@ -43,8 +43,7 @@ public class PublicKeyDaoImpl extends AbstractDaoImpl<PublicKey> implements Publ
 
     @Override
     public List<PublicKey> findAll() {
-        Query query = entityManager.createQuery("select x from ?1 x");
-        query.setParameter(1, modelClass.getSimpleName());
+        Query query = entityManager.createQuery("select x from " + modelClass.getSimpleName() + " x");
         @SuppressWarnings("unchecked")
         List<PublicKey> results = query.getResultList();
 

--- a/src/main/java/org/oscarehr/common/dao/RBTGroupDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/RBTGroupDaoImpl.java
@@ -54,16 +54,15 @@ public class RBTGroupDaoImpl extends AbstractDaoImpl<RBTGroup> implements RBTGro
      */
     @Override
     public int deleteByNameAndTemplateId(String groupName, Integer templateId) {
-        StringBuilder buf = new StringBuilder("DELETE FROM ?1 g WHERE g.groupName = ?2");
+        StringBuilder buf = new StringBuilder("DELETE FROM " + modelClass.getSimpleName() + " g WHERE g.groupName = ?1");
         if (templateId != null) {
-            buf.append(" AND g.templateId = ?3");
+            buf.append(" AND g.templateId = ?2");
         }
 
         Query query = entityManager.createQuery(buf.toString());
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, groupName);
+        query.setParameter(1, groupName);
         if (templateId != null) {
-            query.setParameter(3, templateId);
+            query.setParameter(2, templateId);
         }
 
         return query.executeUpdate();

--- a/src/main/java/org/oscarehr/common/dao/RelationshipsDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/RelationshipsDaoImpl.java
@@ -52,35 +52,31 @@ public class RelationshipsDaoImpl extends AbstractDaoImpl<Relationships> impleme
 
     @Override
     public Relationships findActive(Integer id) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.id = ?2 AND (r.deleted IS NULL OR r.deleted = '0')");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, id);
+        Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName() + " r WHERE r.id = ?1 AND (r.deleted IS NULL OR r.deleted = '0')");
+        query.setParameter(1, id);
         return getSingleResultOrNull(query);
     }
 
     @Override
     public List<Relationships> findByDemographicNumber(Integer demographicNumber) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.demographicNo = ?2 AND (r.deleted IS NULL OR r.deleted = '0')");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicNumber);
+        Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName() + " r WHERE r.demographicNo = ?1 AND (r.deleted IS NULL OR r.deleted = '0')");
+        query.setParameter(1, demographicNumber);
         return query.getResultList();
     }
 
     @Override
     public List<Relationships> findActiveSubDecisionMaker(Integer demographicNumber) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.demographicNo = ?2 AND r.subDecisionMaker = ?3 AND (r.deleted IS NULL OR r.deleted = '0')");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicNumber);
-        query.setParameter(3, ConversionUtils.toBoolString(Boolean.TRUE));
+        Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName() + " r WHERE r.demographicNo = ?1 AND r.subDecisionMaker = ?2 AND (r.deleted IS NULL OR r.deleted = '0')");
+        query.setParameter(1, demographicNumber);
+        query.setParameter(2, ConversionUtils.toBoolString(Boolean.TRUE));
         return query.getResultList();
     }
 
     @Override
     public List<Relationships> findActiveByDemographicNumberAndFacility(Integer demographicNumber, Integer facilityId) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.demographicNo = ?2 AND r.facilityId = ?3 AND (r.deleted IS NULL OR r.deleted = '0')");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, demographicNumber);
-        query.setParameter(3, facilityId);
+        Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName() + " r WHERE r.demographicNo = ?1 AND r.facilityId = ?2 AND (r.deleted IS NULL OR r.deleted = '0')");
+        query.setParameter(1, demographicNumber);
+        query.setParameter(2, facilityId);
         return query.getResultList();
     }
 }

--- a/src/main/java/org/oscarehr/common/dao/RemoteReferralDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/RemoteReferralDaoImpl.java
@@ -42,11 +42,10 @@ public class RemoteReferralDaoImpl extends AbstractDaoImpl<RemoteReferral> imple
 
     @Override
     public List<RemoteReferral> findByFacilityIdDemogprahicId(Integer facilityId, Integer demographicId) {
-        String sql = "select x from ?1 x where x.facilityId=?2 and x.demographicId=?3";
+        String sql = "select x from " + modelClass.getSimpleName() + " x where x.facilityId=?1 and x.demographicId=?2";
         Query query = entityManager.createQuery(sql);
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, facilityId);
-        query.setParameter(3, demographicId);
+        query.setParameter(1, facilityId);
+        query.setParameter(2, demographicId);
 
         @SuppressWarnings("unchecked")
         List<RemoteReferral> results = query.getResultList();

--- a/src/main/java/org/oscarehr/common/dao/ResourceStorageDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ResourceStorageDaoImpl.java
@@ -44,33 +44,33 @@ public class ResourceStorageDaoImpl extends AbstractDaoImpl<ResourceStorage> imp
 
     @Override
     public ResourceStorage findActive(String resourceType) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.resourceType = ?2 AND r.active = true");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, resourceType);
+        String sqlCommand = "FROM " + modelClass.getSimpleName() + " r WHERE r.resourceType = ?1 AND r.active = true";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, resourceType);
         return getSingleResultOrNull(query);
     }
 
     @Override
     public List<ResourceStorage> findActiveAll(String resourceType) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.resourceType = ?2 AND r.active = true");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, resourceType);
+        String sqlCommand = "FROM " + modelClass.getSimpleName() + " r WHERE r.resourceType = ?1 AND r.active = true";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, resourceType);
         return query.getResultList();
     }
 
     @Override
     public List<ResourceStorage> findAll(String resourceType) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.resourceType = ?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, resourceType);
+        String sqlCommand = "FROM " + modelClass.getSimpleName() + " r WHERE r.resourceType = ?1";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, resourceType);
         return query.getResultList();
     }
 
     @Override
     public List<ResourceStorage> findByUUID(String uuid) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.uuid = ?2");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, uuid);
+        String sqlCommand = "FROM " + modelClass.getSimpleName() + " r WHERE r.uuid = ?1";
+        Query query = entityManager.createQuery(sqlCommand);
+        query.setParameter(1, uuid);
         return query.getResultList();
     }
 

--- a/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/ScheduleDateDaoImpl.java
@@ -44,7 +44,7 @@ public class ScheduleDateDaoImpl extends AbstractDaoImpl<ScheduleDate> implement
 
     @Override
     public ScheduleDate findByProviderNoAndDate(String providerNo, Date date) {
-        Query query = entityManager.createQuery("select s from ScheduleDate s where s.providerNo=?1 and s.date=?2 and s.status=?");
+        Query query = entityManager.createQuery("select s from ScheduleDate s where s.providerNo=?1 and s.date=?2 and s.status=?3");
         query.setParameter(1, providerNo);
         query.setParameter(2, date);
         query.setParameter(3, 'A');

--- a/src/main/java/org/oscarehr/common/dao/SurveillanceDataDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/SurveillanceDataDaoImpl.java
@@ -43,17 +43,15 @@ public class SurveillanceDataDaoImpl extends AbstractDaoImpl<SurveillanceData> i
 
     @Override
     public List<SurveillanceData> findExportDataBySurveyId(String surveyId) {
-        Query query = entityManager.createQuery("FROM ?1 r WHERE r.surveyId = ?2 order by r.createDate desc");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, surveyId);
+        Query query = entityManager.createQuery("FROM " + modelClass.getSimpleName() + " r WHERE r.surveyId = ?1 order by r.createDate desc");
+        query.setParameter(1, surveyId);
         return query.getResultList();
     }
 
     @Override
     public List<SurveillanceData> findUnSentBySurveyId(String surveyId) {
         Query query = entityManager.createQuery("FROM ?1 r WHERE r.surveyId = ?2 and r.sent = false");
-        query.setParameter(1, modelClass.getSimpleName());
-        query.setParameter(2, surveyId);
+        query.setParameter(1, surveyId);
         return query.getResultList();
     }
 }


### PR DESCRIPTION
## Changes made
- Removed any positional parameter _before_ the `WHERE` clause in JPA queries.
- These changes were exclusively where positional parameters were used to inject the `modelClass` name into the query as the table name.

## Summary by Sourcery

Bug Fixes:
- Correct table name usage in JPA queries by directly embedding the model class name into the query string instead of using positional parameters.