### PR TITLE
Upgrade Spring framework to 5.3.X

### DIFF
--- a/dependencies-lock.json
+++ b/dependencies-lock.json
@@ -770,11 +770,11 @@
   }, {
     "groupId" : "commons-net",
     "artifactId" : "commons-net",
-    "version" : "3.3",
+    "version" : "3.6",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:aAwgcrMBzfGbyzUlpSkodNSQPdHND9g7mv+0Y1SJTOpKL+GSQU2lyC7RJQYzZbih8ajyOEno7X5KI3joqSSeqQ=="
+    "integrity" : "sha512:26QUzqn7S0ff5tIMNHvZEFIYXdlYmWv90ecJ9mtfp4Euuw2tgMR+crzAB1s7VSbHBSFu/nccrBzFOy95IxJPrw=="
   }, {
     "groupId" : "commons-pool",
     "artifactId" : "commons-pool",
@@ -887,6 +887,14 @@
     "type" : "jar",
     "optional" : false,
     "integrity" : "sha512:puEPXfKeBNuh5MptzuGJt47rdP18U1HZv0ZjPOUTiRg0+KEWC2Kw7T07jHXcmbAC2eIezycmjW67z61tK3fsXg=="
+  }, {
+    "groupId" : "io.projectreactor",
+    "artifactId" : "reactor-core",
+    "version" : "3.3.22.RELEASE",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:oio3IAodBcf4uXftxExiWEUSTu+IEfNpnrChGsUWUSjmA6mfbP1SPv24UrrLmLcorhsyoHgzwOs0JIOh/+fptQ=="
   }, {
     "groupId" : "janino",
     "artifactId" : "janino",
@@ -2171,11 +2179,11 @@
   }, {
     "groupId" : "org.aspectj",
     "artifactId" : "aspectjweaver",
-    "version" : "1.8.9",
+    "version" : "1.9.7",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:euqAZi/98bBUwWqArQRg2sDR6qIcN0Z3I0sQVnyvfRaVX8K4+ehAq8pRMfBdVaiwQ7v4O+na6slnRuY/5u0rlA=="
+    "integrity" : "sha512:SQ/PI4SGhI4ny+1F/UN2Exk8nol0iggY+1Mq7VwhOqsmJNFI7Z/VgIDGk02l9+wSxk5Atku0bRbjYetAQ5PFug=="
   }, {
     "groupId" : "org.atmosphere",
     "artifactId" : "atmosphere-runtime",
@@ -2961,6 +2969,14 @@
     "optional" : false,
     "integrity" : "sha512:E5L7Ktczeq/CRP00N0GKdeXTDEqmOWB4IE/le2CUYgeOfCAjw8FBfN2XhIZg8oiV/xgo1ZMutvnYd4xTmku5bA=="
   }, {
+    "groupId" : "org.reactivestreams",
+    "artifactId" : "reactive-streams",
+    "version" : "1.0.3",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:qvyGGG2CtPO9RO9/lVl4SBFy6rJn0giqgLJPjKIYvZAtabWH/K4v5EqIi3qfgfxaIJ6DeVgwf9wO6BUkj3Bl+Q=="
+  }, {
     "groupId" : "org.reflections",
     "artifactId" : "reflections",
     "version" : "0.9.9-RC1",
@@ -2995,155 +3011,155 @@
   }, {
     "groupId" : "org.springframework.integration",
     "artifactId" : "spring-integration-core",
-    "version" : "4.2.4.RELEASE",
+    "version" : "5.3.10.RELEASE",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:Cml/f0YWoAu977JzN/EUzPoYNBOt9UIqkCbAVta4KOa44yP49nSVXJva8PF6c08RUEDPdile7GMhRotv7M0q4g=="
+    "integrity" : "sha512:tkdZ9FuQfIdZagtJrG/LMEbtFmc54IWLbX67bf++3vwirjDdZGYSwEI/Qirg2MwF7sdSghGb12zqMAtuQz299w=="
   }, {
     "groupId" : "org.springframework.integration",
     "artifactId" : "spring-integration-file",
-    "version" : "4.2.4.RELEASE",
+    "version" : "5.3.10.RELEASE",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:kp4ODI2WNiYdi6FXjqbh+evhApA0AFPy3kmCYPw3xL9P+QrmdLrbMm+U6GBrbQZme/aL9MfUwIHrNO/o/qHQmQ=="
+    "integrity" : "sha512:GTQFkbG7ewkI0ZzNYz0LyoVWR8QDHgQhiiWbBrtTZtYomrnll+qfnRwLS93DsUnl5GRHLrzZ48hRyLUJUK+dXw=="
   }, {
     "groupId" : "org.springframework.integration",
     "artifactId" : "spring-integration-ftp",
-    "version" : "4.2.4.RELEASE",
+    "version" : "5.3.10.RELEASE",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7cF7FG1SZQ9E92gXrKmckTHRZmsvMj+ELR6yMbPX9PTVrfw72pCuheSAJAYLCbDCFlsbgBM8+MY75WVEPxOybg=="
+    "integrity" : "sha512:bKuJtd9Ey+dm58C9ho42ETy4wz84wlZS64Z4Y/x7GogRu5cKfUPZ/oNPzD0RoCEneww8N6KyDFHVlkWA0LkvlA=="
   }, {
     "groupId" : "org.springframework.integration",
     "artifactId" : "spring-integration-sftp",
-    "version" : "4.2.4.RELEASE",
+    "version" : "5.3.10.RELEASE",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:A/L0MQniHcJgs+AEULIb7txhTBVF4ybYZ1H4DAgdpQTPCWCFXf4tXsC+sL6Q8IbVsu6bM5SyMhJIOSqr7wR5kw=="
-  }, {
-    "groupId" : "org.springframework.integration",
-    "artifactId" : "spring-integration-stream",
-    "version" : "4.2.4.RELEASE",
-    "scope" : "compile",
-    "type" : "jar",
-    "optional" : false,
-    "integrity" : "sha512:tmLNvr2BThfc2Qnx9P3g7yMR6j6lE5l1QVlqdhpgoRSqk/AqyqkV78UTwX5V9PSGVVjUQdck0lY9zLOT80FhIA=="
+    "integrity" : "sha512:O+2ETfhGZHSQEVjGDZs10ixXtWuW4h6pNR/aeqcBEuzFClXF388aAjfNUwpdDFBwDKGF0GrpuyQLFLhs/2PZ1g=="
   }, {
     "groupId" : "org.springframework.retry",
     "artifactId" : "spring-retry",
-    "version" : "1.1.2.RELEASE",
+    "version" : "1.2.5.RELEASE",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:69vFpDGFVg9xxTjx/ClXNn6MBqRQesdAj+JSfEngno0dt3FhqkTBfmyt/T7DPTZI/iFvFqt1Mwbx9Oae6Y8lrg=="
+    "integrity" : "sha512:JE41MaU4Lxe2TQI0tfqAUi7hrxqTGFPU4vnKz5A3ZRNNvOHOzPxHb+Tfkf0z3qYbWhLpSVpHa2QPCxeqa+dWig=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aop",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:q5SmXSz0JjfxdkkpcclKmVTepCow3d/Kl8dONGtGwMk5rC9kxmXXXDm2ePKyhwgKwT4VMLvCSRoIlfG7rTu00Q=="
+    "integrity" : "sha512:EtIwkT9X/ZdHZoEBa3DEEdLSVXw6rWochlQVY6uXd4bymqUncSbhXvwTN9M6fm/swF3rsyhXv6H0jJlD2ZNiBQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-aspects",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:4BmYVkU8dYS1dR0VvA+reubmnNTntyNzBCH8B5HWnxENrtz23o2xf6q1JhAqhvANrUm6DXZ3btqvS/1uu5J/2g=="
+    "integrity" : "sha512:Go07gcXM7RPC1rGups8R7gyh6u1hAXz++rOZYOv57+DcCGXaux600ZToZ8sSgyYtHWh4CdrZsZ1JABR2uYM+Ug=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-beans",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:LiWf7yFcj+ozU5wrqjIU2+kWTPPtLUIakDrUnJc88DGKYdFpaVJvFzvTK383BglSLTVO1cOaA0i7VSZVMjeEPA=="
+    "integrity" : "sha512:UzIdM5XlGy0LaUit/0zOgaenEsia+SzietmKRONL+076DmF7lRwEaN6wuq+iWOr2FQeYKmd009gyWT0SnJPzzg=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-context-support",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:iz6D1CE8v1xuY9dFdduq+6WGcI9UhSilzW1h9rf94xdYxf4RK/cxOj96TAID+6hYjqUhDO5C2QK3DxWZRK3ncg=="
+    "integrity" : "sha512:MmND6TYiCAUEd8AIUGXzrlerdeS9EJIhGZCrtytUJ07zaiOf+yyTIveVRcWfOmSb4ODoMB8m3McCgs9h4Wyyig=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-context",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mDXEGI2pn5cjx8d7+EanzXjOz13xPzaU/Zzns3obLWDRbQ/PJnV879028J7D02jxbQZ6ARufPPxbvbuJjQt23w=="
+    "integrity" : "sha512:IjJbtgXdjKyMtF9cncDdhwFKCb7TdNfzQQCi/Xx3AFqYAOsYyxxZw/hOIT8G7Mv8zrguD9uZJZ1MZBhRGoutgQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-core",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:9xZLVJb6YUGiol3we4/pFAdxiUQ68Hi2nMIEfRpwtKlRovcRZt34ajaexuAeHoc4Pxc623aIrI1+kNvjAGMSnw=="
+    "integrity" : "sha512:JinteaCjz+fkZ6waEPbQ2T+Ovfn+eb9n2Z5Xl+Tv22ux/VTviCZ2shdb7qFAecpaxtghjJQTSma9VE2D/I3CtQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-expression",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:mApmGjqJaDSq2KDzRVF5uWrrd7laeK1kA/58eTMlbWbMFFM4SA692UxUuR1BKPjrEU2J5VEah6+y2lAzigYW7Q=="
+    "integrity" : "sha512:UaxnmJWcmdmFB6jAkSqTyHLyf0Tgouu3vx01zMiMVWnHoH3qR9nXQNWwGaA6wsnwOu/JSvuY/ioyWK4L8UwE5A=="
+  }, {
+    "groupId" : "org.springframework",
+    "artifactId" : "spring-jcl",
+    "version" : "5.3.39",
+    "scope" : "compile",
+    "type" : "jar",
+    "optional" : false,
+    "integrity" : "sha512:Vde0+nHhvlB88ZvBjWvOA1lGqna4PhYVKhjoIuCNz1cRQ5Nru6jGr15X6BZjUtgH9Tho/qUpfroa3PX2XZ/dFg=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-jdbc",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:jL9Q3zUsL3fXtiHO/F88uD2L/59UUrNONCMlaB8jFD9qyrbzNCBOBSgyQwcwnkzVh4e6exMGJSsgRfNoaS5Gkw=="
+    "integrity" : "sha512:n7wLbtOLlizchNGi6mI5NDDUR9PomXk7aNB2dNpnv6U7IvHqJEk9c38jbHbtCtaEhRM5fvIiWoxiMuUWrhUuoQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-messaging",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:0fy78c7wc5x5+ZX7IobSPFuUz5/RUdgTp+8ShUxAcvTpBOR4jqINPnHNJHG5ku41iNdx63aUyt3SlSKrOvXcmw=="
+    "integrity" : "sha512:Dto49i3yV7hKoGYBZZoHz/XJmPjlhZlvVyMFULF3Ca8zg+sUubxDsEoxHgiOqYPgKtrnwtSDfaH2/iCDzo18sQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-orm",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:bBoY/cQF8QAdop/AFu6kip8nSZr+cWoXVDaRZJ3vHb0JIJkIxtH0xpJ/hx5dGXqpKihPI7ivKrsQGxQrQ6xrOA=="
+    "integrity" : "sha512:nz9SpG8rTUWk1gpYF9pRFiL3WTpTblLF6clPVaJOYNggYHtsIM/qdqv+kAFwmjq49a2oglH3styX7cQkudAPRg=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-test",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:HdPuMz9N+90UJdzi624ChjfjfdecYeRBBPC4irP2ywuD+3hBhxN6vl6V5StOc6wnJE5x+csvn1/NiFV1fv7L9g=="
+    "integrity" : "sha512:58743Lzz2DhNxqhgx3HOUUJTlmp0p8n5CJteeY3/dzlkhDGStVofv9iTigXsxNUplCRMA2FhZshteyYSVzaZXw=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-tx",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:8dn3RMPoOYoG7AtvFdNsJ5VgIq16NjfFgRFQFzZjx4XyDaDa/LwN1vNBwu++NEh93IGWTWaEYNnKSrG8Rkfjpg=="
+    "integrity" : "sha512:B+2ECV/GupsUToPzTpJAdpyRJm9lW+mATZS6kziGzEd1NgAdE2P+SH09drX35C7PhjIyk9ZlS50xmNxy3irBbQ=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-web",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:qjEz6HC6Ma9Z6v36/PRhWyuEHw6BVnbdmaceNa0x4eK6SKNDTYLxYeiSNpldFj+R2ZAQ4UfVZK0Q/yv7RVWDkQ=="
+    "integrity" : "sha512:vowFRRgmOo6zoaEpT13mi6GAWMYADi0yvogsXp2919yO4v8fKdfLuSy3WZ+noey+VC/aNXTA0Efe1dTHAhBCCg=="
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-webmvc-struts",
@@ -3155,11 +3171,11 @@
   }, {
     "groupId" : "org.springframework",
     "artifactId" : "spring-webmvc",
-    "version" : "4.3.30.RELEASE",
+    "version" : "5.3.39",
     "scope" : "compile",
     "type" : "jar",
     "optional" : false,
-    "integrity" : "sha512:7s/5A/5QyEzOK/p1/C6o5JaeJz34D4wzmsBWoKCPRTV0idt60qmiyAgjUyj7rOw32x/YhxvAvsAFO4czXcGFog=="
+    "integrity" : "sha512:rA94Jqmh3Upf+6QZyBkU8WOm1jj3PBvyNt3oIIo0N4x8wtgke4xD3b0txAorBh3G9if2S6hs/qLUJef7nzvSUg=="
   }, {
     "groupId" : "org.swinglabs",
     "artifactId" : "pdf-renderer",

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>4.3.30.RELEASE</version>
+                <version>5.3.39</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -248,40 +248,47 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-ftp</artifactId>
-            <version>4.2.4.RELEASE</version>
+            <version>5.3.10.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.integration</groupId>
             <artifactId>spring-integration-sftp</artifactId>
-            <version>4.2.4.RELEASE</version>
+            <version>5.3.10.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aspects</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
+            <version>5.3.39</version>
         </dependency>
         <dependency>
             <groupId>com.onelogin</groupId>

--- a/src/main/java/com/quatro/dao/security/SecProviderDaoImpl.java
+++ b/src/main/java/com/quatro/dao/security/SecProviderDaoImpl.java
@@ -33,7 +33,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.criterion.Example;
 import org.oscarehr.util.MiscUtils;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
 import com.quatro.model.security.SecProvider;
 
@@ -114,7 +114,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
     @Override
     public List findByExample(SecProviderDao instance) {
         logger.debug("finding Provider instance by example");
-        Session session = getSession();
+        Session session = currentSession();
         try {
             List results = session.createCriteria(
                             "com.quatro.model.security.SecProvider").add(
@@ -126,8 +126,6 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         } catch (RuntimeException re) {
             logger.error("find by example failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 
@@ -135,7 +133,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
     public List findByProperty(String propertyName, Object value) {
         logger.debug("finding Provider instance with property: " + propertyName
                 + ", value: " + value);
-        Session session = getSession();
+        Session session = currentSession();
         try {
             String queryString = "from Provider as model where model."
                     + propertyName + "= ?";
@@ -145,8 +143,6 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         } catch (RuntimeException re) {
             logger.error("find by property name failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 
@@ -233,7 +229,7 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
     @Override
     public List findAll() {
         logger.debug("finding all Provider instances");
-        Session session = getSession();
+        Session session = currentSession();
         try {
             String queryString = "from Provider";
             Query queryObject = session.createQuery(queryString);
@@ -241,15 +237,13 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         } catch (RuntimeException re) {
             logger.error("find all failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 
     @Override
     public SecProviderDao merge(SecProviderDao detachedInstance) {
         logger.debug("merging Provider instance");
-        Session session = getSession();
+        Session session = currentSession();
         try {
             SecProviderDao result = (SecProviderDao) session.merge(detachedInstance);
             logger.debug("merge successful");
@@ -257,38 +251,32 @@ public class SecProviderDaoImpl extends HibernateDaoSupport implements SecProvid
         } catch (RuntimeException re) {
             logger.error("merge failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 
     @Override
     public void attachDirty(SecProviderDao instance) {
         logger.debug("attaching dirty Provider instance");
-        Session session = getSession();
+        Session session = currentSession();
         try {
             session.saveOrUpdate(instance);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 
     @Override
     public void attachClean(SecProviderDao instance) {
         logger.debug("attaching clean Provider instance");
-        Session session = getSession();
+        Session session = currentSession();
         try {
             session.lock(instance, LockMode.NONE);
             logger.debug("attach successful");
         } catch (RuntimeException re) {
             logger.error("attach failed", re);
             throw re;
-        } finally {
-            this.releaseSession(session);
         }
     }
 }

--- a/src/main/java/org/oscarehr/PMmodule/dao/ProgramSignatureDaoImpl.java
+++ b/src/main/java/org/oscarehr/PMmodule/dao/ProgramSignatureDaoImpl.java
@@ -33,7 +33,7 @@ import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.oscarehr.PMmodule.model.ProgramSignature;
 import org.oscarehr.util.MiscUtils;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
 public class ProgramSignatureDaoImpl extends HibernateDaoSupport implements ProgramSignatureDao {
 

--- a/src/main/java/org/oscarehr/common/dao/PopulationReportDaoImpl.java
+++ b/src/main/java/org/oscarehr/common/dao/PopulationReportDaoImpl.java
@@ -51,7 +51,7 @@ import org.oscarehr.common.model.Stay;
 import org.oscarehr.util.DbConnectionFilter;
 import org.oscarehr.util.MiscUtils;
 import org.oscarehr.util.EncounterUtil.EncounterType;
-import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+import org.springframework.orm.hibernate5.support.HibernateDaoSupport;
 
 import oscar.util.SqlUtils;
 


### PR DESCRIPTION
## Changes made
- Update springframework packages to 5.3.X
- Use `org.springframework.hibernate5` instead of `org.springframework.hibernate3` in:
  - SecProviderDaoImpl.java
  - ProgramSignatureDaoImpl.java
  - PopulationReportDaoImpl.java

## Summary by Sourcery

Upgrade Spring framework and related dependencies to improve compatibility and performance. Update DAO implementations to use the latest Hibernate support.

Enhancements:
- Update Spring framework dependencies to version 5.3.39.
- Replace usage of 'org.springframework.hibernate3' with 'org.springframework.hibernate5' in DAO implementations.
- Upgrade 'commons-net' dependency from version 3.3 to 3.6.
- Upgrade 'aspectjweaver' dependency from version 1.8.9 to 1.9.7.
- Add new dependencies: 'reactor-core' version 3.3.22.RELEASE and 'reactive-streams' version 1.0.3.